### PR TITLE
Bail out of struct generation less agressively when we are able to generate.

### DIFF
--- a/SharpGen.UnitTests/Parsing/Struct.cs
+++ b/SharpGen.UnitTests/Parsing/Struct.cs
@@ -72,6 +72,8 @@ namespace SharpGen.UnitTests.Parsing
 
             var generatedStruct = model.FindFirst<CppStruct>("Test");
 
+            Assert.True(generatedStruct.IsUnion);
+
             var field = generatedStruct.FindFirst<CppField>("Test::field1");
 
             Assert.NotNull(field);

--- a/SharpGen/CppModel/CppStruct.cs
+++ b/SharpGen/CppModel/CppStruct.cs
@@ -51,5 +51,8 @@ namespace SharpGen.CppModel
         {
             get { return Iterate<CppField>(); }
         }
+
+        [XmlAttribute("union")]
+        public bool IsUnion { get; set; }
     }
 }

--- a/SharpGen/Logging/LoggingCodes.cs
+++ b/SharpGen/Logging/LoggingCodes.cs
@@ -4,7 +4,7 @@ using System.Text;
 
 namespace SharpGen.Logging
 {
-    public class LoggingCodes
+    public static class LoggingCodes
     {
         public const string MissingConfigDependency = "SG0001";
 
@@ -38,7 +38,7 @@ namespace SharpGen.Logging
 
         public const string UnknownFundamentalType = "SG0017";
 
-        public const string ImpossibleAlignment = "SG0018";
+        public const string NonPortableAlignment = "SG0018";
 
         public const string UnusedMappingRule = "SG0019";
 

--- a/SharpGen/Model/CsStruct.cs
+++ b/SharpGen/Model/CsStruct.cs
@@ -55,9 +55,10 @@ namespace SharpGen.Model
             IsStaticMarshal = tag.IsStaticMarshal ?? false;
             HasCustomNew = tag.StructCustomNew ?? false;
 
-            // Force a marshalling if a struct need to be treated as a class)
-            if (GenerateAsClass)
+            if (HasCustomMarshal || IsStaticMarshal || HasCustomNew || GenerateAsClass)
+            {
                 HasMarshalType = true;
+            }
         }
 
         public override int Size => _Size_;

--- a/SharpGen/Parser/CppParser.cs
+++ b/SharpGen/Parser/CppParser.cs
@@ -643,6 +643,7 @@ namespace SharpGen.Parser
             cppStruct = new CppStruct { Name = structName };
             xElement.AddAnnotation(cppStruct);
             var isUnion = (xElement.Name.LocalName == CastXml.TagUnion);
+            cppStruct.IsUnion = isUnion;
 
             // Get align from structure
             cppStruct.Align = int.Parse(xElement.AttributeValue("align")) / 8;

--- a/SharpGen/Transform/StructTransform.cs
+++ b/SharpGen/Transform/StructTransform.cs
@@ -137,7 +137,6 @@ namespace SharpGen.Transform
 
             int cumulatedBitOffset = 0;
 
-
             var inheritedStructs = new Stack<CppStruct>();
             var currentStruct = cppStruct;
             while (currentStruct != null && currentStruct.Base != currentStruct.Name)
@@ -173,7 +172,6 @@ namespace SharpGen.Transform
                         // BoolToInt doesn't generate native Marshaling although they have a different marshaller
                         if ((!csField.IsBoolToInt || csField.IsArray) && fieldHasMarshalType)
                             hasMarshalType = true;
-
 
                         // If last field has same offset, then it's a union
                         // CurrentOffset is not moved
@@ -213,7 +211,6 @@ namespace SharpGen.Transform
                             csField.BitMask = ((1 << cppField.BitOffset) - 1);
                             csField.BitOffset = lastCumulatedBitOffset;
                         }
-
 
                         var nextFieldIndex = fieldIndex + 1;
                         if ((previousFieldOffsetIndex == cppField.Offset)

--- a/SharpGen/Transform/StructTransform.cs
+++ b/SharpGen/Transform/StructTransform.cs
@@ -251,7 +251,7 @@ namespace SharpGen.Transform
                         {
                             Logger.Error(
                                 LoggingCodes.NonPortableAlignment,
-                                "The field [{0}] in structure [{1}] has pointer alignment within a structure that contains an union. An explicit layout cannot be handled on both x86/x64. This structure needs manual layout (remove fields from definition) and write them manually in xml mapping files",
+                                "The field [{0}] in structure [{1}] has pointer alignment within a structure that requires explicit layout. This situation cannot be handled on both 32-bit and 64-bit architectures. This structure needs manual layout (remove fields from definition) and write them manually in xml mapping files",
                                 field.CppElementName,
                                 csStruct.CppElementName);
                             break;


### PR DESCRIPTION
Only report non-portable alignment when we actually can't generate the native structure and we are told to autogenerate.

Cases where we can continue but were erroring out:

- Unions: Since every member has an offset of 0, we can correctly place all members at the correct offset.
- Custom Marshalling: We aren't generating the native structure in this case, so we shouldn't error out saying we can't.

Cases where we continue to error out:

- Any explicitly laid out structures where a field would have to be placed after a pointer field. We can't calculate compile-time offsets that are valid for both 32-bit and 64-bit programs.
