### PR TITLE
Use IntPtr instead of void* for PointerSize marshal type (#72)

### DIFF
--- a/SharpGen/Transform/MarshalledElementFactory.cs
+++ b/SharpGen/Transform/MarshalledElementFactory.cs
@@ -154,7 +154,7 @@ namespace SharpGen.Transform
 
             if (publicType.QualifiedName == globalNamespace.GetTypeName(WellKnownName.PointerSize))
             {
-                marshalType = typeRegistry.ImportType(typeof(void*));
+                marshalType = typeRegistry.ImportType(typeof(IntPtr));
             }
 
             // Present void* elements as IntPtr. Marshal strings as IntPtr


### PR DESCRIPTION
This is a fix for #72 (haven't been able to test it, but it should work better, can't push it directly to master)