### PR TITLE
Allow users to specify additional arguments for CastXML when it is parsing C++.

### DIFF
--- a/SharpGen.Interactive/CodeGenApp.cs
+++ b/SharpGen.Interactive/CodeGenApp.cs
@@ -406,7 +406,7 @@ namespace SharpGen.Interactive
                 Logger.Fatal("Initializing parser failed");
 
             // Run the parser
-            group = parser.Run(group);
+            group = parser.Run(group, Array.Empty<string>());
 
             if (Logger.HasErrors)
             {

--- a/SharpGen.UnitTests/Parsing/ParsingTestBase.cs
+++ b/SharpGen.UnitTests/Parsing/ParsingTestBase.cs
@@ -44,7 +44,7 @@ namespace SharpGen.UnitTests.Parsing
             };
         }
 
-        protected CppModule ParseCpp(ConfigFile config)
+        protected CppModule ParseCpp(ConfigFile config, string[] additionalArguments = null)
         {
             var loaded = ConfigFile.Load(config, new string[0], Logger);
 
@@ -84,7 +84,7 @@ namespace SharpGen.UnitTests.Parsing
 
             parser.Initialize(loaded);
 
-            return parser.Run(skeleton);
+            return parser.Run(skeleton, additionalArguments ?? Array.Empty<string>());
         }
     }
 }

--- a/SharpGen/Parser/CastXml.cs
+++ b/SharpGen/Parser/CastXml.cs
@@ -144,7 +144,7 @@ namespace SharpGen.Parser
                 if (!File.Exists(headerFile))
                     Logger.Fatal("C++ Header file [{0}] not found", headerFile);
 
-                RunCastXml(headerFile, handler, "-E -dD");
+                RunCastXml(headerFile, handler, $"-E -dD");
             });
         }
 
@@ -153,7 +153,7 @@ namespace SharpGen.Parser
         /// </summary>
         /// <param name="headerFile">The header headerFile.</param>
         /// <returns></returns>
-        public StreamReader Process(string headerFile)
+        public StreamReader Process(string headerFile, string[] additionalArguments)
         {
             StreamReader result = null;
 
@@ -168,7 +168,7 @@ namespace SharpGen.Parser
                 // Delete any previously generated xml file
                 File.Delete(xmlFile);
 
-                RunCastXml(headerFile, LogCastXmlOutput, $"-o {xmlFile}");
+                RunCastXml(headerFile, LogCastXmlOutput, $"-o {xmlFile} {string.Join(" ", additionalArguments)}");
 
                 if (!File.Exists(xmlFile) || Logger.HasErrors)
                 {

--- a/SharpGen/Parser/CppParser.cs
+++ b/SharpGen/Parser/CppParser.cs
@@ -156,7 +156,7 @@ namespace SharpGen.Parser
         /// Runs this instance.
         /// </summary>
         /// <returns></returns>
-        public CppModule Run(CppModule groupSkeleton)
+        public CppModule Run(CppModule groupSkeleton, string[] additionalCompilationArguments)
         {
             _group = groupSkeleton;
             Logger.Message("Config files changed.");
@@ -171,7 +171,7 @@ namespace SharpGen.Parser
 
                 var configRootHeader = Path.Combine(OutputPath, _configRoot.Id + ".h");
 
-                xmlReader = _gccxml.Process(configRootHeader);
+                xmlReader = _gccxml.Process(configRootHeader, additionalCompilationArguments);
                 if (xmlReader != null)
                 {
                     Parse(xmlReader);

--- a/SharpGenTools.Sdk/SharpGenTools.Sdk.targets
+++ b/SharpGenTools.Sdk/SharpGenTools.Sdk.targets
@@ -166,6 +166,7 @@
       OutputPath="$(MSBuildProjectDirectory)/$(SharpGenIntermediateDir)"
       PartialCppModuleCache="@(PartialCppModule)"
       ParsedCppModule="@(ParsedCppModule)"
+      CastXmlArguments="@(CastXmlArg)"
     />
   </Target>
 

--- a/SharpGenTools.Sdk/Tasks/ParseCPlusPlus.cs
+++ b/SharpGenTools.Sdk/Tasks/ParseCPlusPlus.cs
@@ -1,10 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using Microsoft.Build.Framework;
+﻿using Microsoft.Build.Framework;
 using SharpGen.Config;
 using SharpGen.CppModel;
 using SharpGen.Parser;
+using System;
 
 namespace SharpGenTools.Sdk.Tasks
 {
@@ -21,6 +19,8 @@ namespace SharpGenTools.Sdk.Tasks
 
         [Required]
         public ITaskItem ParsedCppModule { get; set; }
+
+        public string[] CastXmlArguments { get; set; }
 
         protected override bool Execute(ConfigFile config)
         {
@@ -45,7 +45,7 @@ namespace SharpGenTools.Sdk.Tasks
             var module = CppModule.Read(PartialCppModuleCache.ItemSpec);
 
             // Run the parser
-            var group = parser.Run(module);
+            var group = parser.Run(module, CastXmlArguments ?? Array.Empty<string>());
 
             if (SharpGenLogger.HasErrors)
                 return false;

--- a/docs/advanced-configuration.rst
+++ b/docs/advanced-configuration.rst
@@ -40,3 +40,14 @@ Some of the options above control the output directory for generated code. The t
 
     * If ``SharpGenIncludeAssemblyNameFolder`` is false, ``$(SharpGenOutputDirectory)/$(SharpGenGeneratedCodeFolder)``
     * If ``SharpGenIncludeAssemblyNameFolder`` is true, ``$(SharpGenOutputDirectory)/SharpGenAssemblyName/$(SharpGenGeneratedCodeFolder)``
+
+
+CastXML Customization
+=========================
+
+    * ``CastXmlExecutablePath``
+
+        * A path to a custom build of CastXML.
+    * ``CastXmlArg`` MSBuild Items
+
+        * Additional arguments to pass to CastXML when parsing the C++ code.


### PR DESCRIPTION
Fixes #77.