### PR TITLE
Emit GC.KeepAlive in cleanup code to keep interface class instances alive.

### DIFF
--- a/SharpGen/Generator/Marshallers/ArrayOfInterfaceMarshaller.cs
+++ b/SharpGen/Generator/Marshallers/ArrayOfInterfaceMarshaller.cs
@@ -96,7 +96,7 @@ namespace SharpGen.Generator.Marshallers
 
         public StatementSyntax GenerateNativeCleanup(CsMarshalBase csElement, bool singleStackFrame)
         {
-            return null;
+            return GenerateGCKeepAlive(csElement);
         }
 
         public StatementSyntax GenerateNativeToManaged(CsMarshalBase csElement, bool singleStackFrame)

--- a/SharpGen/Generator/Marshallers/InterfaceMarshaller.cs
+++ b/SharpGen/Generator/Marshallers/InterfaceMarshaller.cs
@@ -101,7 +101,7 @@ namespace SharpGen.Generator.Marshallers
 
         public StatementSyntax GenerateNativeCleanup(CsMarshalBase csElement, bool singleStackFrame)
         {
-            return null;
+            return GenerateGCKeepAlive(csElement);
         }
 
         public StatementSyntax GenerateNativeToManaged(CsMarshalBase csElement, bool singleStackFrame)

--- a/SharpGen/Generator/Marshallers/MarshallerBase.cs
+++ b/SharpGen/Generator/Marshallers/MarshallerBase.cs
@@ -369,5 +369,19 @@ namespace SharpGen.Generator.Marshallers
 
             return param;
         }
+
+        protected StatementSyntax GenerateGCKeepAlive(CsMarshalBase csElement)
+        {
+            return ExpressionStatement(
+                InvocationExpression(
+                    ParseName("System.GC.KeepAlive"),
+                    ArgumentList(
+                        SingletonSeparatedList(
+                            Argument(IdentifierName(csElement.Name))
+                        )
+                    )
+                )
+            );
+        }
     }
 }


### PR DESCRIPTION
Fixes #95.