### PR TITLE
Add included files to the MSBuild Up-to-Date checks.

### DIFF
--- a/SharpGen.UnitTests/Parsing/MacroManagerTests.cs
+++ b/SharpGen.UnitTests/Parsing/MacroManagerTests.cs
@@ -1,0 +1,47 @@
+﻿using SharpGen.Config;
+using SharpGen.Parser;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Xunit;
+
+namespace SharpGen.UnitTests.Parsing
+{
+    public class MacroManagerTests : ParsingTestBase
+    {
+        public MacroManagerTests(Xunit.Abstractions.ITestOutputHelper outputHelper)
+            : base(outputHelper)
+        {
+        }
+
+        [Fact]
+        public void MacroManagerCollectsIncludedHeaders()
+        {
+            CreateCppFile("included", "");
+
+            var includeRule = GetTestFileIncludeRule();
+
+            var config = new ConfigFile
+            {
+                Id = nameof(MacroManagerCollectsIncludedHeaders),
+                Assembly = nameof(MacroManagerCollectsIncludedHeaders),
+                Namespace = nameof(MacroManagerCollectsIncludedHeaders),
+                IncludeDirs = { includeRule },
+                Includes =
+                {
+                    CreateCppFile("includer", "#include \"included.h\"")
+                }
+            };
+
+            var castXml = GetCastXml(ConfigFile.Load(config, Array.Empty<string>(), Logger));
+
+            var macroManager = new MacroManager(castXml);
+
+            macroManager.Parse(Path.Combine(includeRule.Path, "includer.h"), new CppModel.CppModule());
+
+            Assert.Contains(includeRule.Path + "/included.h",
+                macroManager.IncludedFiles);
+        }
+    }
+}

--- a/SharpGen.UnitTests/Parsing/ParsingTestBase.cs
+++ b/SharpGen.UnitTests/Parsing/ParsingTestBase.cs
@@ -44,6 +44,20 @@ namespace SharpGen.UnitTests.Parsing
             };
         }
 
+        protected CastXml GetCastXml(ConfigFile config, string[] additionalArguments = null)
+        {
+            var resolver = new IncludeDirectoryResolver(Logger);
+            resolver.Configure(config);
+            return new CastXml(
+                Logger,
+                resolver,
+                CastXmlExecutablePath,
+                additionalArguments ?? Array.Empty<string>())
+            {
+                OutputPath = TestDirectory.FullName
+            };
+        }
+
         protected CppModule ParseCpp(ConfigFile config, string[] additionalArguments = null)
         {
             var loaded = ConfigFile.Load(config, new string[0], Logger);
@@ -64,14 +78,7 @@ namespace SharpGen.UnitTests.Parsing
 
             var (updated, _) = cppHeaderGenerator.GenerateCppHeaders(loaded, configsWithIncludes, filesWithExtensionHeaders);
 
-            var resolver = new IncludeDirectoryResolver(Logger);
-
-            resolver.Configure(loaded);
-
-            var castXml = new CastXml(Logger, resolver, CastXmlExecutablePath, additionalArguments ?? Array.Empty<string>())
-            {
-                OutputPath = TestDirectory.FullName
-            };
+            var castXml = GetCastXml(loaded);
 
             var extensionGenerator = new CppExtensionHeaderGenerator(new MacroManager(castXml));
 

--- a/SharpGen/Parser/MacroManager.cs
+++ b/SharpGen/Parser/MacroManager.cs
@@ -36,6 +36,7 @@ namespace SharpGen.Parser
         private readonly CastXml _gccxml;
         private Dictionary<string, string> _currentMacros = null;
         private readonly Dictionary<string, Dictionary<string, string>> _mapIncludeToMacros = new Dictionary<string, Dictionary<string, string>>();
+        private readonly List<string> _includedFiles = new List<string>();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="MacroManager"/> class.
@@ -45,6 +46,8 @@ namespace SharpGen.Parser
         {
             _gccxml = gccxml;
         }
+
+        public IEnumerable<string> IncludedFiles => _includedFiles;
 
         /// <summary>
         /// Parses the specified C++ header file and fills the <see cref="CppModule"/> with defined macros.
@@ -88,7 +91,10 @@ namespace SharpGen.Parser
                         _currentMacros = null;
                     else
                     {
+                        _includedFiles.Add(result.Groups[1].Value.Replace(@"\\", @"\"));
                         var currentFile = Path.GetFileName(result.Groups[1].Value);
+
+
                         if (!_mapIncludeToMacros.TryGetValue(currentFile, out _currentMacros))
                         {
                             _currentMacros = new Dictionary<string,string>();

--- a/SharpGen/Parser/MacroManager.cs
+++ b/SharpGen/Parser/MacroManager.cs
@@ -94,7 +94,6 @@ namespace SharpGen.Parser
                         _includedFiles.Add(result.Groups[1].Value.Replace(@"\\", @"\"));
                         var currentFile = Path.GetFileName(result.Groups[1].Value);
 
-
                         if (!_mapIncludeToMacros.TryGetValue(currentFile, out _currentMacros))
                         {
                             _currentMacros = new Dictionary<string,string>();
@@ -103,7 +102,7 @@ namespace SharpGen.Parser
                     }
                 }
                 else if (_currentMacros != null)
-                {                    
+                {
                     result = MatchDefine.Match(line);
                     if (result.Success)
                     {

--- a/SharpGenTools.Sdk/GenerateConsumerBindMappingFile.targets
+++ b/SharpGenTools.Sdk/GenerateConsumerBindMappingFile.targets
@@ -1,3 +1,0 @@
-﻿<Project>
-  <Target Name="GenerateConsumerBindMappingFile" />
-</Project>

--- a/SharpGenTools.Sdk/GetSnPath.Core.props
+++ b/SharpGenTools.Sdk/GetSnPath.Core.props
@@ -1,5 +1,9 @@
 <Project>
-    <Target Name="GetSnPath" Condition="'$(SnPath)' == '' OR !Exists('$(SnPath)')">
+  <PropertyGroup>
+    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+  </PropertyGroup>
+
+  <Target Name="GetSnPath" Condition="'$(SnPath)' == '' OR !Exists('$(SnPath)')">
         <Exec Command="where sn &gt; sn-path.txt" ContinueOnError="true" Condition="'$(OS)' == 'Windows_NT'" WorkingDirectory="$(IntermediateOutputPath)" />
         <Exec Command="which sn &gt; sn-path.txt" ContinueOnError="true" Condition="'$(OS)' == 'Unix'" WorkingDirectory="$(IntermediateOutputPath)"  />
         <ReadLinesFromFile File="$(IntermediateOutputPath)/sn-path.txt">

--- a/SharpGenTools.Sdk/GetSnPath.Full.props
+++ b/SharpGenTools.Sdk/GetSnPath.Full.props
@@ -1,4 +1,8 @@
 <Project>
+  <PropertyGroup>
+    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+  </PropertyGroup>
+  
   <!-- Pulled from https://stackoverflow.com/questions/12781870/how-should-i-reference-sn-exe-in-msbuild-script -->
   <Target Name="GetSnPath" Condition="'$(SnPath)' == '' OR !Exists('$(SnPath)')">
     <GetFrameworkSdkPath>

--- a/SharpGenTools.Sdk/GetSnPath.Mono.props
+++ b/SharpGenTools.Sdk/GetSnPath.Mono.props
@@ -1,5 +1,9 @@
 <Project>
-    <Target Name="GetSnPath" Condition="'$(SnPath)' == '' OR !Exists('$(SnPath)')">
+  <PropertyGroup>
+    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+  </PropertyGroup>
+
+  <Target Name="GetSnPath" Condition="'$(SnPath)' == '' OR !Exists('$(SnPath)')">
         <Exec Command="where sn &gt; sn-path.txt" ContinueOnError="true" Condition="'$(OS)' == 'Windows_NT'" WorkingDirectory="$(IntermediateOutputPath)" />
         <Exec Command="which sn &gt; sn-path.txt" ContinueOnError="true" Condition="'$(OS)' == 'Unix'" WorkingDirectory="$(IntermediateOutputPath)"  />
         <ReadLinesFromFile File="$(IntermediateOutputPath)/sn-path.txt">

--- a/SharpGenTools.Sdk/SharpGenTools.Sdk.props
+++ b/SharpGenTools.Sdk/SharpGenTools.Sdk.props
@@ -1,5 +1,9 @@
 ﻿<Project>
   <PropertyGroup>
+    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+  </PropertyGroup>
+
+  <PropertyGroup>
     <SharpGenGenerateConsumerBindMapping Condition="'$(SharpGenGenerateConsumerBindMapping)' == ''">true</SharpGenGenerateConsumerBindMapping>
     <SharpGenGenerateDoc Condition="'$(SharpGenGenerateDoc)' == ''">false</SharpGenGenerateDoc>
     <SharpGenGlobalNamespace Condition="'$(SharpGenGlobalNamespace)' == ''">SharpGen.Runtime</SharpGenGlobalNamespace>

--- a/SharpGenTools.Sdk/SharpGenTools.Sdk.targets
+++ b/SharpGenTools.Sdk/SharpGenTools.Sdk.targets
@@ -1,17 +1,26 @@
 ﻿<Project>
   <PropertyGroup>
+    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+  </PropertyGroup>
+  
+  <PropertyGroup>
     <SharpGenIntermediateDir>$(IntermediateOutputPath)SharpGen/</SharpGenIntermediateDir>
     <SharpGenDocumentationOutputDir Condition="'$(SharpGenDocumentationOutputDir)' == ''">$(SharpGenIntermediateDir)</SharpGenDocumentationOutputDir>
     <ShadowCopyDocumentationOutput Condition="'$(SharpGenDocumentationOutputDir)' != '$(SharpGenIntermediateDir)'">true</ShadowCopyDocumentationOutput>
     <SharpGenGeneratedCodeFolder Condition="'$(SharpGenGeneratedCodeFolder)' == ''">$(SharpGenIntermediateDir)Generated</SharpGenGeneratedCodeFolder>
     <SharpGenConsumerBindMappingConfigId Condition="'$(SharpGenConsumerBindMappingConfigId)' == ''">$(AssemblyName)</SharpGenConsumerBindMappingConfigId>
     <SharpGenOutputDirectory Condition="'$(SharpGenOutputDirectory)' == ''">$(MSBuildProjectDirectory)</SharpGenOutputDirectory>
-    <GenerateConsumerBindMappingFilePlaceholderProperty>CustomBeforeMicrosoftCommonTargets=$(MSBuildThisFileDirectory)/GenerateConsumerBindMappingFile.targets</GenerateConsumerBindMappingFilePlaceholderProperty>
   </PropertyGroup>
 
+  <ItemGroup Condition="'$(SharpGenSdkAssembly)' == ''">
+    <SharpGenSdkAssembly Condition="'$(MSBuildRuntimeType)' == 'Core'"
+                         Include="$(MSBuildThisFileDirectory)/../tools/netstandard1.3/SharpGenTools.Sdk.dll" />
+    <SharpGenSdkAssembly Condition="'$(MSBuildRuntimeType)' != 'Core'"
+                         Include="$(MSBuildThisFileDirectory)/../tools/net46/SharpGenTools.Sdk.dll" />
+  </ItemGroup>
+
   <ItemGroup>
-    <SharpGenSdkAssembly Condition="'$(MSBuildRuntimeType)' == 'Core'" Include="$(MSBuildThisFileDirectory)/../tools/netstandard1.3/SharpGenTools.Sdk.dll" />
-    <SharpGenSdkAssembly Condition="'$(MSBuildRuntimeType)' != 'Core'" Include="$(MSBuildThisFileDirectory)/../tools/net46/SharpGenTools.Sdk.dll" />
+    <SharpGenIncludedHeadersCache Include="$(SharpGenIntermediateDir)HeadersCache.txt" />
     <SharpGenSdkCheckFile Include="$(SharpGenIntermediateDir)Sdk.checkfile" />
     <CppConsumerConfig Include="$(SharpGenIntermediateDir)CppConsumerConfig.xml" />
     <PartialCppModule Include="$(SharpGenIntermediateDir)PartialCppModule.xml" />
@@ -44,7 +53,9 @@
       Projects="@(_MSBuildProjectReferenceExistent)"
       Targets="GenerateConsumerBindMappingFile"
       BuildInParallel="$(BuildInParallel)"
-      Properties="%(_MSBuildProjectReferenceExistent.SetConfiguration); %(_MSBuildProjectReferenceExistent.SetPlatform); %(_MSBuildProjectReferenceExistent.SetTargetFramework); $(GenerateConsumerBindMappingFilePlaceholderProperty)"
+      Properties="%(_MSBuildProjectReferenceExistent.SetConfiguration);
+                  %(_MSBuildProjectReferenceExistent.SetPlatform);"
+      SkipNonexistentTargets="true"
       ContinueOnError="$(ContinueOnError)"
       RemoveProperties="%(_MSBuildProjectReferenceExistent.GlobalPropertiesToRemove)">
       <Output TaskParameter="TargetOutputs" ItemName="SharpGenConsumerMapping" />
@@ -109,7 +120,7 @@
           Inputs="@(SharpGenSdkAssembly)"
           Outputs="@(SharpGenSdkCheckFile)">
     <CreateProperty Value="true">
-      <Output TaskParameter="ValueSetByTask"  PropertyName="NewSdkAssembly" />
+      <Output TaskParameter="ValueSetByTask" PropertyName="NewSdkAssembly" />
     </CreateProperty>
   </Target>
 
@@ -127,6 +138,12 @@
       <Output TaskParameter="Headers" ItemName="Headers" />
       <Output TaskParameter="ExtensionHeaders" ItemName="ExtensionHeaders" />
     </GetGeneratedHeaderNames>
+
+    <ReadLinesFromFile
+      Condition="Exists('@(SharpGenIncludedHeadersCache)')"
+      File="@(SharpGenIncludedHeadersCache)">
+      <Output TaskParameter="Lines" ItemName="IncludedHeaders" />
+    </ReadLinesFromFile>
   </Target>
 
   <Target
@@ -150,7 +167,7 @@
   <Target
     Name="GenerateExtensionHeaders"
     DependsOnTargets="PrepareCppGeneration;GenerateHeaders"
-    Inputs="@(SharpGenSdkAssembly);@(SharpGenMapping);@(SharpGenConsumerMapping);@(Headers)"
+    Inputs="@(SharpGenSdkAssembly);@(SharpGenMapping);@(SharpGenConsumerMapping);@(Headers);@(IncludedHeaders)"
     Outputs="@(ExtensionHeaders);@(PartialCppModule)"
     Condition="'@(SharpGenMapping)' != ''">
     <GenerateExtensionHeaders
@@ -161,14 +178,23 @@
       OutputPath="$(MSBuildProjectDirectory)/$(SharpGenIntermediateDir)"
       PartialCppModuleCache="@(PartialCppModule)"
       UpdatedConfigs="@(UpdatedConfigs)"
-      CastXmlArguments="@(CastXmlArg)"
-    />
+      CastXmlArguments="@(CastXmlArg)">
+      <Output TaskParameter="ReferencedHeaders" ItemName="IncludedHeaders" />
+    </GenerateExtensionHeaders>
+
+    <RemoveDuplicates Inputs="@(IncludedHeaders)">
+      <Output TaskParameter="Filtered" ItemName="FilteredHeaders" />
+    </RemoveDuplicates>
+
+    <WriteLinesToFile
+      File="@(SharpGenIncludedHeadersCache)"
+      Lines="@(FilteredHeaders)" />
   </Target>
 
   <Target
     Name="ParseCPlusPlus"
     DependsOnTargets="GenerateHeaders;GenerateExtensionHeaders"
-    Inputs="@(SharpGenSdkAssembly);@(SharpGenMapping);@(SharpGenConsumerMapping);@(PartialCppModule)"
+    Inputs="@(SharpGenSdkAssembly);@(SharpGenMapping);@(SharpGenConsumerMapping);@(PartialCppModule);@(IncludedHeaders)"
     Outputs="@(ParsedCppModule)"
     Condition="'@(SharpGenMapping)' != ''">
     <ParseCPlusPlus

--- a/SharpGenTools.Sdk/Tasks/GenerateExtensionHeaders.cs
+++ b/SharpGenTools.Sdk/Tasks/GenerateExtensionHeaders.cs
@@ -30,6 +30,9 @@ namespace SharpGenTools.Sdk.Tasks
         [Required]
         public string[] CastXmlArguments { get; set; }
 
+        [Output]
+        public ITaskItem[] ReferencedHeaders { get; set; }
+
         protected override bool Execute(ConfigFile config)
         {
             var configsWithExtensions = new HashSet<string>();
@@ -55,9 +58,13 @@ namespace SharpGenTools.Sdk.Tasks
                 OutputPath = OutputPath
             };
 
-            var cppExtensionGenerator = new CppExtensionHeaderGenerator(new MacroManager(castXml));
+            var macroManager = new MacroManager(castXml);
+
+            var cppExtensionGenerator = new CppExtensionHeaderGenerator(macroManager);
 
             var module = cppExtensionGenerator.GenerateExtensionHeaders(config, OutputPath, configsWithExtensions, updatedConfigs);
+
+            ReferencedHeaders = macroManager.IncludedFiles.Select(file => new TaskItem(file)).ToArray();
 
             if (SharpGenLogger.HasErrors)
             {

--- a/build/build-outerloop-native.ps1
+++ b/build/build-outerloop-native.ps1
@@ -1,7 +1,7 @@
 Push-Location SdkTests/Native
 
 try {
-    cmake -A x64 | Write-Host
+    cmake . -A x64 | Write-Host
 
     if ($LastExitCode -ne 0) {
         Write-Error "Failed to generate native projects"


### PR DESCRIPTION
Add included files to MSBuild up-to-date checks so incremental builds will update when the native headers change.

Clean up support for P2P dependencies that aren't referencing SharpGen.
