### PR TITLE
CastXML off-Windows resolution fixes

### DIFF
--- a/SharpGen/Parser/CastXml.cs
+++ b/SharpGen/Parser/CastXml.cs
@@ -113,7 +113,7 @@ namespace SharpGen.Parser
         public const string TagFunctionType = "FunctionType";
 
         /// <summary>
-        /// Gets or sets the executable path of gccxml.exe.
+        /// Gets or sets the executable path of castxml.
         /// </summary>
         /// <value>The executable path.</value>
         public string ExecutablePath { get; }
@@ -145,7 +145,7 @@ namespace SharpGen.Parser
             Logger.RunInContext(nameof(Preprocess), () =>
             {
                 if (!File.Exists(ExecutablePath))
-                    Logger.Fatal("castxml.exe not found from path: [{0}]", ExecutablePath);
+                    Logger.Fatal("castxml not found from path: [{0}]", ExecutablePath);
 
                 if (!File.Exists(headerFile))
                     Logger.Fatal("C++ Header file [{0}] not found", headerFile);
@@ -165,7 +165,7 @@ namespace SharpGen.Parser
 
             Logger.RunInContext(nameof(Process), () =>
             {
-                if (!File.Exists(ExecutablePath)) Logger.Fatal("castxml.exe not found from path: [{0}]", ExecutablePath);
+                if (!File.Exists(ExecutablePath)) Logger.Fatal("castxml not found from path: [{0}]", ExecutablePath);
 
                 if (!File.Exists(headerFile)) Logger.Fatal("C++ Header file [{0}] not found", headerFile);
 

--- a/SharpGenTools.Sdk/SharpGenTools.Sdk.props
+++ b/SharpGenTools.Sdk/SharpGenTools.Sdk.props
@@ -7,7 +7,7 @@
     <SharpGenGenerateConsumerBindMapping Condition="'$(SharpGenGenerateConsumerBindMapping)' == ''">true</SharpGenGenerateConsumerBindMapping>
     <SharpGenGenerateDoc Condition="'$(SharpGenGenerateDoc)' == ''">false</SharpGenGenerateDoc>
     <SharpGenGlobalNamespace Condition="'$(SharpGenGlobalNamespace)' == ''">SharpGen.Runtime</SharpGenGlobalNamespace>
-    <CastXmlPath Condition="'$(CastXmlPath)' == ''">$(MSBuildThisFileDirectory)../tools/CastXML/bin/castxml.exe</CastXmlPath>
+    <CastXmlPath Condition="('$(CastXmlPath)' == '') and ('$(OS)'  == 'Windows_NT')">$(MSBuildThisFileDirectory)../tools/CastXML/bin/castxml.exe</CastXmlPath>
     <CppStandard Condition="'$(CppStandard)' == ''">c++14</CppStandard>
   </PropertyGroup>
 </Project>

--- a/docs/advanced-configuration.rst
+++ b/docs/advanced-configuration.rst
@@ -45,7 +45,7 @@ Some of the options above control the output directory for generated code. The t
 CastXML Customization
 =========================
 
-    * ``CastXmlExecutablePath``
+    * ``CastXmlPath``
 
         * A path to a custom build of CastXML.
     * ``CastXmlArg`` MSBuild Items


### PR DESCRIPTION
Update documentation for CastXML resolution.

Don't set default CastXML path off-Windows (to force users to specify a CastXML path).

Contributes to #111 