### PR TITLE
Fix handling of unsupported multi-indirection marshallable scenarios

### DIFF
--- a/SharpGen.UnitTests/MarshalledElementFactoryTests.cs
+++ b/SharpGen.UnitTests/MarshalledElementFactoryTests.cs
@@ -385,5 +385,43 @@ namespace SharpGen.UnitTests
 
             AssertLoggingCodeLogged(LoggingCodes.InvalidRelation);
         }
+
+        [Fact]
+        public void DoublePointerNonInterfaceParameterMappedAsIntPtr()
+        {
+            var cppParameter = new CppParameter
+            {
+                TypeName = "int",
+                Pointer = "**"
+            };
+
+            var typeRegistry = new TypeRegistry(Logger, A.Fake<IDocumentationLinker>());
+            typeRegistry.BindType("int", typeRegistry.ImportType(typeof(int)));
+            var marshalledElementFactory = new MarshalledElementFactory(Logger, new GlobalNamespaceProvider("SharpGen.Runtime"), typeRegistry);
+            var csParameter = marshalledElementFactory.Create(cppParameter);
+
+            Assert.Equal(typeRegistry.ImportType(typeof(IntPtr)), csParameter.PublicType);
+            Assert.Equal(typeRegistry.ImportType(typeof(IntPtr)), csParameter.MarshalType);
+            Assert.True(csParameter.HasPointer);
+        }
+
+        [Fact]
+        public void PointerNonInterfaceReturnValueMappedAsIntPtr()
+        {
+            var cppReturnValue = new CppReturnValue
+            {
+                TypeName = "int",
+                Pointer = "*"
+            };
+
+            var typeRegistry = new TypeRegistry(Logger, A.Fake<IDocumentationLinker>());
+            typeRegistry.BindType("int", typeRegistry.ImportType(typeof(int)));
+            var marshalledElementFactory = new MarshalledElementFactory(Logger, new GlobalNamespaceProvider("SharpGen.Runtime"), typeRegistry);
+            var csReturnValue = marshalledElementFactory.Create(cppReturnValue);
+
+            Assert.Equal(typeRegistry.ImportType(typeof(IntPtr)), csReturnValue.PublicType);
+            Assert.Equal(typeRegistry.ImportType(typeof(IntPtr)), csReturnValue.MarshalType);
+            Assert.True(csReturnValue.HasPointer);
+        }
     }
 }

--- a/SharpGen.UnitTests/MarshalledElementFactoryTests.cs
+++ b/SharpGen.UnitTests/MarshalledElementFactoryTests.cs
@@ -423,5 +423,28 @@ namespace SharpGen.UnitTests
             Assert.Equal(typeRegistry.ImportType(typeof(IntPtr)), csReturnValue.MarshalType);
             Assert.True(csReturnValue.HasPointer);
         }
+
+
+        [Fact]
+        public void TriplePointerInterfaceParameterMappedAsIntPtr()
+        {
+            var cppParameter = new CppParameter
+            {
+                TypeName = "Interface",
+                Pointer = "***"
+            };
+
+            var typeRegistry = new TypeRegistry(Logger, A.Fake<IDocumentationLinker>());
+            typeRegistry.BindType("Interface", new CsInterface { Name = "Interface" });
+
+            var marshalledElementFactory = new MarshalledElementFactory(Logger, new GlobalNamespaceProvider("SharpGen.Runtime"), typeRegistry);
+
+            var csParameter = marshalledElementFactory.Create(cppParameter);
+
+            Assert.Equal(typeRegistry.ImportType(typeof(IntPtr)), csParameter.PublicType);
+            Assert.Equal(typeRegistry.ImportType(typeof(IntPtr)), csParameter.MarshalType);
+            Assert.True(csParameter.HasPointer);
+        }
+
     }
 }

--- a/SharpGen.UnitTests/MarshalledElementFactoryTests.cs
+++ b/SharpGen.UnitTests/MarshalledElementFactoryTests.cs
@@ -406,6 +406,27 @@ namespace SharpGen.UnitTests
         }
 
         [Fact]
+        public void DoubleVoidPointerParameterPreserved()
+        {
+            var cppParameter = new CppParameter
+            {
+                TypeName = "void",
+                Pointer = "**",
+                Attribute = ParamAttribute.Out
+            };
+
+            var typeRegistry = new TypeRegistry(Logger, A.Fake<IDocumentationLinker>());
+            typeRegistry.BindType("void", typeRegistry.ImportType(typeof(void)));
+            var marshalledElementFactory = new MarshalledElementFactory(Logger, new GlobalNamespaceProvider("SharpGen.Runtime"), typeRegistry);
+            var csParameter = marshalledElementFactory.Create(cppParameter);
+
+            Assert.Equal(typeRegistry.ImportType(typeof(IntPtr)), csParameter.PublicType);
+            Assert.Equal(typeRegistry.ImportType(typeof(IntPtr)), csParameter.MarshalType);
+            Assert.True(csParameter.HasPointer);
+            Assert.True(csParameter.IsOut);
+        }
+
+        [Fact]
         public void PointerNonInterfaceReturnValueMappedAsIntPtr()
         {
             var cppReturnValue = new CppReturnValue

--- a/SharpGen/Transform/MarshalledElementFactory.cs
+++ b/SharpGen/Transform/MarshalledElementFactory.cs
@@ -4,6 +4,7 @@ using SharpGen.Logging;
 using SharpGen.Model;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 
 namespace SharpGen.Transform
@@ -198,25 +199,34 @@ namespace SharpGen.Transform
 
         public CsReturnValue Create(CppReturnValue cppReturnValue)
         {
-            return CreateCore<CsReturnValue>(cppReturnValue);
+            var retVal = CreateCore<CsReturnValue>(cppReturnValue);
+
+            MakeGeneralPointersBeIntPtr(retVal);
+
+            return retVal;
         }
 
         public CsField Create(CppField cppField)
         {
             var field = CreateCore<CsField>(cppField);
 
-            if (field.HasPointer)
-            {
-                field.MarshalType = typeRegistry.ImportType(typeof(IntPtr));
-                if (field.PublicType != typeRegistry.ImportType(typeof(string)) && !field.IsInterface)
-                {
-                    field.PublicType = typeRegistry.ImportType(typeof(IntPtr));
-                }
-            }
+            MakeGeneralPointersBeIntPtr(field);
 
             field.IsBitField = cppField.IsBitField;
 
             return field;
+        }
+
+        private void MakeGeneralPointersBeIntPtr(CsMarshalBase csMarshallable)
+        {
+            if (csMarshallable.HasPointer)
+            {
+                csMarshallable.MarshalType = typeRegistry.ImportType(typeof(IntPtr));
+                if (csMarshallable.PublicType != typeRegistry.ImportType(typeof(string)) && !csMarshallable.IsInterface)
+                {
+                    csMarshallable.PublicType = typeRegistry.ImportType(typeof(IntPtr));
+                }
+            }
         }
 
         public CsParameter Create(CppParameter cppParameter)
@@ -235,6 +245,7 @@ namespace SharpGen.Transform
             var marshalType = param.MarshalType;
 
             var parameterAttribute = CsParameterAttribute.In;
+            var numIndirections = cppParameter.Pointer?.Count(p => p == '*' || p == '&') ?? 0;
 
             if (hasArray)
             {
@@ -254,8 +265,10 @@ namespace SharpGen.Transform
                     // Force Interface** to be ParamAttribute.Out when None
                     if (cppAttribute == ParamAttribute.In || cppAttribute == ParamAttribute.None)
                     {
-                        if (cppParameter.Pointer == "**")
+                        if (numIndirections == 2)
+                        {
                             cppAttribute = ParamAttribute.Out;
+                        }
                     }
 
                     if ((cppAttribute & ParamAttribute.In) != 0 || (cppAttribute & ParamAttribute.InOut) != 0)
@@ -269,7 +282,9 @@ namespace SharpGen.Transform
                         }
                     }
                     else if ((cppAttribute & ParamAttribute.Out) != 0)
+                    {
                         parameterAttribute = CsParameterAttribute.Out;
+                    }
                 }
                 else
                 {
@@ -300,10 +315,18 @@ namespace SharpGen.Transform
                         parameterAttribute = CsParameterAttribute.Out;
 
                     // Handle void* with Buffer attribute
-                    if (cppParameter.GetTypeNameWithMapping() == "void" && (cppAttribute & ParamAttribute.Buffer) != 0)
+                    if ((cppParameter.GetTypeNameWithMapping() == "void" && (cppAttribute & ParamAttribute.Buffer) != 0))
                     {
                         hasArray = false;
                         parameterAttribute = CsParameterAttribute.In;
+                    }
+                    // There's no way to know how to deallocate native-allocated memory correctly since we don't know what allocator the native memory uses
+                    // so we treat double-pointer indirections as IntPtr
+                    else if (numIndirections > 1)
+                    {
+                        marshalType = publicType = typeRegistry.ImportType(typeof(IntPtr));
+                        parameterAttribute = CsParameterAttribute.In;
+                        hasArray = false;
                     }
                     else if (publicType is CsFundamentalType fundamental && fundamental.Type == typeof(string)
                         && (cppAttribute & ParamAttribute.Out) != 0)

--- a/SharpGen/Transform/MarshalledElementFactory.cs
+++ b/SharpGen/Transform/MarshalledElementFactory.cs
@@ -324,14 +324,14 @@ namespace SharpGen.Transform
                         parameterAttribute = CsParameterAttribute.Out;
 
                     // Handle void* with Buffer attribute
-                    if ((cppParameter.GetTypeNameWithMapping() == "void" && (cppAttribute & ParamAttribute.Buffer) != 0))
+                    if (cppParameter.GetTypeNameWithMapping() == "void" && (cppAttribute & ParamAttribute.Buffer) != 0)
                     {
                         hasArray = false;
                         parameterAttribute = CsParameterAttribute.In;
                     }
                     // There's no way to know how to deallocate native-allocated memory correctly since we don't know what allocator the native memory uses
                     // so we treat double-pointer indirections as IntPtr
-                    else if (numIndirections > 1)
+                    else if (numIndirections > 1 && cppParameter.GetTypeNameWithMapping() != "void")
                     {
                         marshalType = publicType = typeRegistry.ImportType(typeof(IntPtr));
                         parameterAttribute = CsParameterAttribute.In;

--- a/SharpGen/Transform/MarshalledElementFactory.cs
+++ b/SharpGen/Transform/MarshalledElementFactory.cs
@@ -285,6 +285,15 @@ namespace SharpGen.Transform
                     {
                         parameterAttribute = CsParameterAttribute.Out;
                     }
+
+                    // There's no way to know how to deallocate native-allocated memory correctly since we don't know what allocator the native memory uses
+                    // so we treat triple-pointer indirections as IntPtr
+                    if (numIndirections > 2)
+                    {
+                        marshalType = publicType = typeRegistry.ImportType(typeof(IntPtr));
+                        parameterAttribute = CsParameterAttribute.In;
+                        hasArray = false;
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
Make multiple-indirection non-interface parameters and indirection non-string/interface return values automatically map to IntPtr instead of incorrectly mapping as their underlying type (with up to one level of indirection for parameters)

Fixes #113 