### PR TITLE
Improve IDE integration with SharpGenTools.Sdk.

### DIFF
--- a/SharpGenTools.Sdk/SharpGenMapping.xaml
+++ b/SharpGenTools.Sdk/SharpGenMapping.xaml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ProjectSchemaDefinitions xmlns="http://schemas.microsoft.com/build/2009/properties">
+  <ContentType Name="SharpGenMapping" DisplayName="SharpGen Mapping" ItemType="SharpGenMapping" />
+  <ItemType Name="SharpGenMapping" DisplayName="SharpGen Mapping" />
+
+  <Rule Name="SharpGenMapping" PageTemplate="generic" DisplayName="File Properties" Description="File Properties" PropertyPagesHidden="true">
+    <Rule.DataSource>
+      <DataSource Persistence="ProjectFile" ItemType="SharpGenMapping" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
+    </Rule.DataSource>
+
+    <Rule.Categories>
+      <Category Name="Advanced" DisplayName="Advanced" />
+      <Category Name="Misc" DisplayName="Misc" />
+    </Rule.Categories>
+
+    <DynamicEnumProperty Name="{}{ItemType}" DisplayName="Build Action" Category="Advanced"
+                         Description="How the file relates to the build and deployment processes."
+                         EnumProvider="ItemTypes" />
+
+    <StringProperty Name="Generator"
+                    Category="Advanced"
+                    DisplayName="Custom Tool"
+                    Description="Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool." />
+
+    <StringProperty Name="FullPath"
+                    DisplayName="Full Path"
+                    ReadOnly="true"
+                    Category="Misc"
+                    Description="Location of the file.">
+      <StringProperty.DataSource>
+        <DataSource Persistence="Intrinsic" ItemType="SharpGenMapping" PersistedName="FullPath" SourceOfDefaultValue="AfterContext" />
+      </StringProperty.DataSource>
+    </StringProperty>
+
+    <StringProperty Name="FileNameAndExtension"
+                    DisplayName="File Name"
+                    ReadOnly="true"
+                    Category="Misc"
+                    Description="Name of the file or folder.">
+      <StringProperty.DataSource>
+        <DataSource Persistence="Intrinsic" ItemType="SharpGenMapping" PersistedName="FileNameAndExtension" SourceOfDefaultValue="AfterContext" />
+      </StringProperty.DataSource>
+    </StringProperty>
+
+  </Rule>
+</ProjectSchemaDefinitions>

--- a/SharpGenTools.Sdk/SharpGenTools.Sdk.csproj
+++ b/SharpGenTools.Sdk/SharpGenTools.Sdk.csproj
@@ -28,5 +28,6 @@
 
   <ItemGroup>
     <Content Include="../CastXML/**/*" PackagePath="tools/CastXML/%(RecursiveDir)%(FileName)%(Extension)" />
+    <Content Include="SharpGenMapping.xaml" PackagePath="build" />
   </ItemGroup>
 </Project>

--- a/SharpGenTools.Sdk/SharpGenTools.Sdk.props
+++ b/SharpGenTools.Sdk/SharpGenTools.Sdk.props
@@ -10,4 +10,15 @@
     <CastXmlPath Condition="('$(CastXmlPath)' == '') and ('$(OS)'  == 'Windows_NT')">$(MSBuildThisFileDirectory)../tools/CastXML/bin/castxml.exe</CastXmlPath>
     <CppStandard Condition="'$(CppStandard)' == ''">c++14</CppStandard>
   </PropertyGroup>
+
+  <ItemDefinitionGroup>
+    <SharpGenMapping>
+      <Generator>MSBuild:Compile</Generator>
+    </SharpGenMapping>
+  </ItemDefinitionGroup>
+
+  <ItemGroup>
+    <AvailableItemName Include="SharpGenMapping" />
+    <PropertyPageSchema Include="$(MSBuildThisFileDirectory)../build/SharpGenMapping.xaml" />
+  </ItemGroup>
 </Project>

--- a/SharpGenTools.Sdk/SharpGenTools.Sdk.targets
+++ b/SharpGenTools.Sdk/SharpGenTools.Sdk.targets
@@ -148,7 +148,7 @@
 
   <Target
     Name="GenerateHeaders"
-    DependsOnTargets="PrepareCppGeneration;GetMappingsFromProjectReferences"
+    DependsOnTargets="CreateIntermediateDir;PrepareCppGeneration;GetMappingsFromProjectReferences"
     Inputs="@(SharpGenSdkAssembly);@(SharpGenMapping);@(SharpGenConsumerMapping)"
     Outputs="@(Headers);@(CppConsumerConfig)"
     Condition="'@(SharpGenMapping)' != ''">
@@ -166,7 +166,7 @@
   
   <Target
     Name="GenerateExtensionHeaders"
-    DependsOnTargets="PrepareCppGeneration;GenerateHeaders"
+    DependsOnTargets="CreateIntermediateDir;PrepareCppGeneration;GenerateHeaders"
     Inputs="@(SharpGenSdkAssembly);@(SharpGenMapping);@(SharpGenConsumerMapping);@(Headers);@(IncludedHeaders)"
     Outputs="@(ExtensionHeaders);@(PartialCppModule)"
     Condition="'@(SharpGenMapping)' != ''">
@@ -193,7 +193,7 @@
 
   <Target
     Name="ParseCPlusPlus"
-    DependsOnTargets="GenerateHeaders;GenerateExtensionHeaders"
+    DependsOnTargets="CreateIntermediateDir;GenerateHeaders;GenerateExtensionHeaders"
     Inputs="@(SharpGenSdkAssembly);@(SharpGenMapping);@(SharpGenConsumerMapping);@(PartialCppModule);@(IncludedHeaders)"
     Outputs="@(ParsedCppModule)"
     Condition="'@(SharpGenMapping)' != ''">
@@ -215,7 +215,7 @@
   
   <Target
     Name="MapCppToCSharp"
-    DependsOnTargets="ParseCPlusPlus;$(DocProviderTargets)"
+    DependsOnTargets="CreateIntermediateDir;ParseCPlusPlus;$(DocProviderTargets)"
     Inputs="@(SharpGenSdkAssembly);@(SharpGenMapping);@(ParsedCppModule);@(CppConsumerConfig);@(SharpGenConsumerMapping)"
     Outputs="@(CSharpModel);@(DocLinksCache);@(SharpGenConsumerBindMapping)"
     Condition="'@(SharpGenMapping)' != ''">
@@ -251,7 +251,7 @@
 
   <Target
     Name="GenerateCSharp"
-    DependsOnTargets="GetGeneratedCSharpFiles;RemoveGeneratedCSharpFiles"
+    DependsOnTargets="CreateIntermediateDir;GetGeneratedCSharpFiles;RemoveGeneratedCSharpFiles"
     Inputs="@(SharpGenSdkAssembly);@(CSharpModel);@(DocLinksCache);@(SharpGenExternalDocs)"
     Outputs="@(GeneratedCSharpFiles)"
     Condition="'@(SharpGenMapping)' != ''">


### PR DESCRIPTION
Explicitly add target dependencies on `CreateIntermedateDir`. Rider doesn't actually do design time builds and identifies targets to run at design-time based on heuristics. The `GenerateSharpGenBindings` task doesn't fit this but the other tasks that actually do the work do, so Rider was trying to run the subtasks (without running `CreateIntermediateDir`). By adding this dependency, `CreateIntermediateDir` is run to create the intermediate directory and the SharpGenTools tasks can write to it.

Add some metadata for better VS integration when editing the mapping files.

cc: @kekekeks this fixes the issue with Rider 2019.1 on new projects.
