### PR TITLE
Enable Azure-Pipelines builds

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,9 +1,9 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix Condition="'$(APPVEYOR_REPO_TAG_NAME)' != ''">$(APPVEYOR_REPO_TAG_NAME)</VersionPrefix>
+    <VersionPrefix Condition="'$(ReleaseTag)' != ''">$(ReleaseTag)</VersionPrefix>
     <VersionPrefix Condition="'$(VersionPrefix)' == ''">2.0.0</VersionPrefix>
     <VersionSuffix Condition="'$(CI)' == ''">local</VersionSuffix>
-    <VersionSuffix Condition="'$(CI)' != '' AND '$(APPVEYOR_REPO_TAG_NAME)' == ''">ci.$(APPVEYOR_BUILD_NUMBER)</VersionSuffix>
+    <VersionSuffix Condition="'$(CI)' != '' AND '$(ReleaseTag)' == ''">ci.$(BuildNumber)</VersionSuffix>
     <Authors>jkoritzinsky</Authors>
     <Copyright>(c) 2010-2017 Alexandre Mutel, 2017-2018 Jeremy Koritzinsky</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,13 +4,14 @@ before_build:
 - cmd: dotnet tool install --global coverlet.console
 - cmd: choco install codecov
 - ps: $env:Path = "C:/ProgramData/chocolatey/bin;$env:Path"
+- ps: $env:ReleaseTag = $env:APPVEYOR_REPO_TAG_NAME
+- ps: $env:BuildNumber = $env:APPVEYOR_BUILD_NUMBER
 environment:
   CLI_VERSION: 2.0.0
   MYGET_API_KEY:
     secure: dtTGYQHgEupz5SmTDFkvDW1uEZH7mEM8PD948uzOZY/XCl965mhorbEl2e+6U8pO
   NUGET_API_KEY:
     secure: Vxbun4/HFyJ9eIX1o7qSb2/YwuU/syLy52D0klu8Mla5NjBLC2YmAd6ceBxcT35S
-  
   matrix:
     - Config: Debug
     - Config: Release

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,7 +19,7 @@ environment:
 build_script:
 -  ps: ./build -Configuration $env:Config
 test_script:
--  ps: ./test -Configuration $env:Config; if ($env:Config == 'Debug') { ./build/upload-coverage.ps1 }
+-  ps: ./test -Configuration $env:Config; if ($env:Config -eq 'Debug') { ./build/upload-coverage.ps1 }
 artifacts:
   - path: 'Sharp*\**\Sharp*.nupkg'
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,7 +19,7 @@ environment:
 build_script:
 -  ps: ./build -Configuration $env:Config
 test_script:
--  ps: ./test -Configuration $env:Config
+-  ps: ./test -Configuration $env:Config; if ($env:Config == 'Debug') { ./build/upload-coverage.ps1 }
 artifacts:
   - path: 'Sharp*\**\Sharp*.nupkg'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,7 +27,7 @@ stages:
           value: ''
         - name: CI
           value: true
-        - group: CodeCov
+        - group: SharpGenTools
       steps:
         - pwsh: |
             if ($env:SourceBranch -match 'refs/tags/v(?<Version>.+)')

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,6 +32,7 @@ jobs:
         inputs:
           contents: 'Sharp*/**/Sharp*.nupkg'
           targetFolder: '$(Build.ArtifactStagingDirectory)'
+          flattenFolders: true
       - task: PublishBuildArtifacts@1
         condition: eq(variables['Config'], 'Release')
         displayName: Publish NuGet Packages

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -46,7 +46,7 @@ stages:
           displayName: 'Build SharpGenTools'
           env:
             ReleaseTag: '$(ReleaseVersion)'
-            BuildNumber: '$(Build.BuildNumber)'
+            BuildNumber: 'azp.$(Build.BuildNumber)'
         - pwsh: ./test.ps1 -Configuration $(Config)
           displayName: 'Run Tests'
           env:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,7 +22,7 @@ jobs:
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: "true"
     steps:
       - pwsh: |
-          if ($env:SourceBranch -Matches 'refs/tags/v(?<Version>.+)')
+          if ($env:SourceBranch -match 'refs/tags/v(?<Version>.+)')
           {
             Write-Host "##vso[task.setvariable variable=ReleaseVersion;]$Matches.Version"
           }

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,6 +30,7 @@ jobs:
       - pwsh: ./test.ps1 -Configuration $(Config)
         displayName: 'Run Tests'
       - task: PublishTestResults@2
+        displayName: 'Publish unit test results'
         inputs:
           testResultsFormat: 'VSTest'
           testResultsFiles: 'SharpGen*.trx'
@@ -38,9 +39,10 @@ jobs:
           buildConfiguration: '$(Config)'
           searchFolder: '$(Build.SourcesDirectory)/artifacts/test-results'
       - task: PublishTestResults@2
+        displayName: 'Publish outerloop test results'
         inputs:
           testResultsFormat: 'VSTest'
-          testResultsFiles: '!SharpGen*.trx'
+          testResultsFiles: '*.trx;!SharpGen*.trx'
           mergeTestResults: true
           testRunTitle: 'Outerloop Tests'
           buildConfiguration: '$(Config)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,6 +8,9 @@ trigger:
 pr:
 - master
 
+variables:
+  buildNumber: $[counter(variables['build.reason'], 1000)]
+
 stages:
 - stage: Build
   jobs:
@@ -50,12 +53,12 @@ stages:
           displayName: 'Build SharpGenTools'
           env:
             ReleaseTag: '$(ReleaseVersion)'
-            BuildNumber: 'azp.$(Build.BuildNumber)'
+            BuildNumber: 'azp.$(buildNumber)'
         - pwsh: ./test.ps1 -Configuration $(Config)
           displayName: 'Run Tests'
           env:
             ReleaseTag: '$(ReleaseVersion)'
-            BuildNumber: 'azp.$(Build.BuildNumber)'
+            BuildNumber: 'azp.$(buildNumber)'
         - pwsh: ./build/upload-coverage.ps1
           displayName: 'Upload Code Coverage results to codecov.io'
           condition: eq(variables['Config'], 'Debug')

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,7 +31,7 @@ jobs:
           contents: 'Sharp*/**/Sharp*.nupkg'
           targetFolder: '$(Build.ArtifactStagingDirectory)'
       - task: PublishBuildArtifacts@1
-        condition: eq($(Configuration), 'Release')
+        condition: eq(variables['Configuration'], 'Release')
         displayName: Publish NuGet Packages
         inputs:
           pathToPublish: '$(Build.ArtifactStagingDirectory)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,8 +9,7 @@ pr:
 - master
 
 stages:
-- stage:
-  displayName: Build
+- stage: Build
   jobs:
     - job: SharpGenTools_Windows
       pool:
@@ -73,10 +72,9 @@ stages:
           inputs:
             pathToPublish: '$(Build.ArtifactStagingDirectory)'
             artifactName: NuGet Packages
-- stage:
+- stage: Deploy
   condition: eq(variables['Build.SourceBranchName'], 'master')
   dependsOn: Build
-  displayName: Deploy
   jobs:
     - job: MyGet_Deploy
       pool:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,7 +19,9 @@ jobs:
         inputs:
           packageType: sdk
           version: 2.1.x
-      - script: dotnet tool install --global coverlet.console CodeCov.Tool
+      - script: |
+          dotnet tool install --global coverlet.console
+          dotnet tool install --global CodeCov.Tool
         displayName: 'Install Code Coverage Tools'
       - pwsh: ./build.ps1 -Configuration $(Configuration)
         displayName: 'Build SharpGenTools'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -78,7 +78,7 @@ stages:
   dependsOn: Build
   displayName: Deploy
   jobs:
-    - job: Deploy to MyGet
+    - job: MyGet_Deploy
       pool:
         vmImage: 'windows-2019'
       steps:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,7 +6,7 @@ pr:
 jobs:
   - job: SharpGenTools_Windows
     pool:
-      vmImage: 'windows2019'
+      vmImage: 'windows-2019'
     strategy:
       matrix:
         Debug:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,65 +8,88 @@ trigger:
 pr:
 - master
 
-jobs:
-  - job: SharpGenTools_Windows
-    pool:
-      vmImage: 'windows-2019'
-    strategy:
-      matrix:
-        Debug:
-          Config: 'Debug'
-        Release:
-          Config: 'Release'
-    variables:
-      DOTNET_SKIP_FIRST_TIME_EXPERIENCE: "true"
-      ReleaseVersion: ''
-      CI: true
-    steps:
-      - pwsh: |
-          if ($env:SourceBranch -match 'refs/tags/v(?<Version>.+)')
-          {
-            Write-Host "##vso[task.setvariable variable=ReleaseVersion;]$Matches.Version"
-          }
-        displayName: 'Get Release Name (if this is a tag-triggered build)'
-        env:
-          SourceBranch : '$(Build.SourceBranch)'
-      - task: UseDotNet@2
-        displayName: 'Install .NET Core Sdk'
-        inputs:
-          packageType: sdk
-          version: 2.2.x
-      - script: |
-          dotnet tool install --global coverlet.console
-          dotnet tool install --global CodeCov.Tool
-        displayName: 'Install Code Coverage Tools'
-      - pwsh: ./build.ps1 -Configuration $(Config)
-        displayName: 'Build SharpGenTools'
-        env:
-          ReleaseTag: '$(ReleaseVersion)'
-          BuildNumber: '$(Build.BuildNumber)'
-      - pwsh: ./test.ps1 -Configuration $(Config)
-        displayName: 'Run Tests'
-        env:
-          ReleaseTag: '$(ReleaseVersion)'
-          BuildNumber: '$(Build.BuildNumber)'
-      - task: PublishTestResults@2
-        displayName: 'Publish unit test results'
-        inputs:
-          testResultsFormat: 'VSTest'
-          testResultsFiles: '*.trx'
-          buildConfiguration: '$(Config)'
-          searchFolder: '$(Build.SourcesDirectory)/artifacts/test-results'
-      - task: CopyFiles@2
-        condition: eq(variables['Config'], 'Release')
-        displayName: 'Copy NuGet packages to Artifact staging directory'
-        inputs:
-          contents: 'Sharp*/**/Sharp*.nupkg'
-          targetFolder: '$(Build.ArtifactStagingDirectory)'
-          flattenFolders: true
-      - task: PublishBuildArtifacts@1
-        condition: eq(variables['Config'], 'Release')
-        displayName: Publish NuGet Packages
-        inputs:
-          pathToPublish: '$(Build.ArtifactStagingDirectory)'
-          artifactName: NuGet Packages
+stages:
+- stage:
+  displayName: Build
+  jobs:
+    - job: SharpGenTools_Windows
+      pool:
+        vmImage: 'windows-2019'
+      strategy:
+        matrix:
+          Debug:
+            Config: 'Debug'
+          Release:
+            Config: 'Release'
+      variables:
+        DOTNET_SKIP_FIRST_TIME_EXPERIENCE: "true"
+        ReleaseVersion: ''
+        CI: true
+      steps:
+        - pwsh: |
+            if ($env:SourceBranch -match 'refs/tags/v(?<Version>.+)')
+            {
+              Write-Host "##vso[task.setvariable variable=ReleaseVersion;]$Matches.Version"
+            }
+          displayName: 'Get Release Name (if this is a tag-triggered build)'
+          env:
+            SourceBranch : '$(Build.SourceBranch)'
+        - task: UseDotNet@2
+          displayName: 'Install .NET Core Sdk'
+          inputs:
+            packageType: sdk
+            version: 2.2.x
+        - script: |
+            dotnet tool install --global coverlet.console
+            dotnet tool install --global CodeCov.Tool
+          displayName: 'Install Code Coverage Tools'
+        - pwsh: ./build.ps1 -Configuration $(Config)
+          displayName: 'Build SharpGenTools'
+          env:
+            ReleaseTag: '$(ReleaseVersion)'
+            BuildNumber: '$(Build.BuildNumber)'
+        - pwsh: ./test.ps1 -Configuration $(Config)
+          displayName: 'Run Tests'
+          env:
+            ReleaseTag: '$(ReleaseVersion)'
+            BuildNumber: 'azp.$(Build.BuildNumber)'
+        - task: PublishTestResults@2
+          displayName: 'Publish unit test results'
+          inputs:
+            testResultsFormat: 'VSTest'
+            testResultsFiles: '*.trx'
+            buildConfiguration: '$(Config)'
+            searchFolder: '$(Build.SourcesDirectory)/artifacts/test-results'
+        - task: CopyFiles@2
+          condition: eq(variables['Config'], 'Release')
+          displayName: 'Copy NuGet packages to Artifact staging directory'
+          inputs:
+            contents: 'Sharp*/**/Sharp*.nupkg'
+            targetFolder: '$(Build.ArtifactStagingDirectory)'
+            flattenFolders: true
+        - task: PublishBuildArtifacts@1
+          condition: eq(variables['Config'], 'Release')
+          displayName: Publish NuGet Packages
+          inputs:
+            pathToPublish: '$(Build.ArtifactStagingDirectory)'
+            artifactName: NuGet Packages
+- stage:
+  condition: eq(variables['Build.SourceBranchName'], 'master')
+  dependsOn: Build
+  displayName: Deploy
+  jobs:
+    - job: Deploy to MyGet
+      pool:
+        vmImage: 'windows-2019'
+      steps:
+        - task: DownloadBuildArtifacts@0
+          inputs:
+            buildType: 'current'
+            downloadType: 'single'
+            artifactName: 'NuGet Packages'
+            downloadPath: '$(Build.ArtifactStagingDirectory)'
+        - task: NuGetCommand@2
+          inputs:
+            command: 'push'
+            nugetFeedType: 'external'
+            publishFeedCredentials: 'MyGet'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,6 +13,8 @@ jobs:
           Config: 'Debug'
         Release:
           Config: 'Release'
+    variables:
+      DOTNET_SKIP_FIRST_TIME_EXPERIENCE: "true"
     steps:
       - task: UseDotNet@2
         displayName: 'Install .NET Core Sdk'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,9 +21,13 @@ stages:
           Release:
             Config: 'Release'
       variables:
-        DOTNET_SKIP_FIRST_TIME_EXPERIENCE: "true"
-        ReleaseVersion: ''
-        CI: true
+        - name: DOTNET_SKIP_FIRST_TIME_EXPERIENCE
+          value: "true"
+        - name: ReleaseVersion
+          value: ''
+        - name: CI
+          value: true
+        - group: CodeCov
       steps:
         - pwsh: |
             if ($env:SourceBranch -match 'refs/tags/v(?<Version>.+)')
@@ -52,6 +56,11 @@ stages:
           env:
             ReleaseTag: '$(ReleaseVersion)'
             BuildNumber: 'azp.$(Build.BuildNumber)'
+        - pwsh: ./build/upload-coverage.ps1
+          displayName: 'Upload Code Coverage results to codecov.io'
+          condition: eq(variables['Config'], 'Debug')
+          env:
+            CODECOV_TOKEN: $(SharpGenTools-CodeCov)
         - task: PublishTestResults@2
           displayName: 'Publish unit test results'
           inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,12 +2,11 @@ trigger:
   branches:
     include:
       - master
-  pr:
-    include:
-      - master
   tags:
     include:
       - v*.*
+pr:
+- master
 
 jobs:
   - job: SharpGenTools_Windows

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,15 +29,31 @@ jobs:
         displayName: 'Build SharpGenTools'
       - pwsh: ./test.ps1 -Configuration $(Config)
         displayName: 'Run Tests'
-      - task: CopyFiles@2
-        displayName: 'Copy NuGet packages to Artifact staging directory'
+      - task: PublishTestResults@2
         inputs:
-          contents: 'Sharp*/**/Sharp*.nupkg'
-          targetFolder: '$(Build.ArtifactStagingDirectory)'
-          flattenFolders: true
-      - task: PublishBuildArtifacts@1
-        condition: eq(variables['Config'], 'Release')
-        displayName: Publish NuGet Packages
+          testResultsFormat: 'VSTest'
+          testResultsFiles: 'SharpGen*.trx'
+          mergeTestResults: true
+          testRunTitle: 'Unit Tests'
+          buildConfiguration: '$(Config)'
+          searchFolder: '$(Build.SourcesDirectory)/artifacts/test-results'
+      - task: PublishTestResults@2
         inputs:
-          pathToPublish: '$(Build.ArtifactStagingDirectory)'
-          artifactName: NuGet Packages
+          testResultsFormat: 'VSTest'
+          testResultsFiles: '!SharpGen*.trx'
+          mergeTestResults: true
+          testRunTitle: 'Outerloop Tests'
+          buildConfiguration: '$(Config)'
+          searchFolder: '$(Build.SourcesDirectory)/artifacts/test-results'
+      - ${{ if eq(variables['Config'], 'Release') }}:
+        - task: CopyFiles@2
+          displayName: 'Copy NuGet packages to Artifact staging directory'
+          inputs:
+            contents: 'Sharp*/**/Sharp*.nupkg'
+            targetFolder: '$(Build.ArtifactStagingDirectory)'
+            flattenFolders: true
+        - task: PublishBuildArtifacts@1
+          displayName: Publish NuGet Packages
+          inputs:
+            pathToPublish: '$(Build.ArtifactStagingDirectory)'
+            artifactName: NuGet Packages

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,38 @@
+trigger:
+- master
+pr:
+- master
+
+jobs:
+  - job: SharpGenTools_Windows
+    pool:
+      vmImage: 'windows2019'
+    strategy:
+      matrix:
+        Debug:
+          Configuration: 'Debug'
+        Release:
+          Configuration: 'Release'
+    steps:
+      - task: UseDotNet@2
+        displayName: 'Install .NET Core Sdk'
+        inputs:
+          packageType: sdk
+          version: 2.1.x
+      - script: dotnet tool install --global coverlet.console CodeCov.Tool
+        displayName: 'Install Code Coverage Tools'
+      - pwsh: ./build.ps1 -Configuration $(Configuration)
+        displayName: 'Build SharpGenTools'
+      - pwsh: ./test.ps1 -Configuration $(Configuration)
+        displayName: 'Run Tests'
+      - task: CopyFiles@2
+        displayName: 'Copy NuGet packages to Artifact staging directory'
+        inputs:
+          contents: 'Sharp*/**/Sharp*.nupkg'
+          targetFolder: '$(Build.ArtifactStagingDirectory)'
+      - task: PublishBuildArtifacts@1
+        condition: eq($(Configuration), 'Release')
+        displayName: Publish NuGet Packages
+        inputs:
+          pathToPublish: '$(Build.ArtifactStagingDirectory)'
+          artifactName: NuGet Packages

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,9 +10,9 @@ jobs:
     strategy:
       matrix:
         Debug:
-          Configuration: 'Debug'
+          Config: 'Debug'
         Release:
-          Configuration: 'Release'
+          Config: 'Release'
     steps:
       - task: UseDotNet@2
         displayName: 'Install .NET Core Sdk'
@@ -23,9 +23,9 @@ jobs:
           dotnet tool install --global coverlet.console
           dotnet tool install --global CodeCov.Tool
         displayName: 'Install Code Coverage Tools'
-      - pwsh: ./build.ps1 -Configuration $(Configuration)
+      - pwsh: ./build.ps1 -Configuration $(Config)
         displayName: 'Build SharpGenTools'
-      - pwsh: ./test.ps1 -Configuration $(Configuration)
+      - pwsh: ./test.ps1 -Configuration $(Config)
         displayName: 'Run Tests'
       - task: CopyFiles@2
         displayName: 'Copy NuGet packages to Artifact staging directory'
@@ -33,7 +33,7 @@ jobs:
           contents: 'Sharp*/**/Sharp*.nupkg'
           targetFolder: '$(Build.ArtifactStagingDirectory)'
       - task: PublishBuildArtifacts@1
-        condition: eq(variables['Configuration'], 'Release')
+        condition: eq(variables['Config'], 'Release')
         displayName: Publish NuGet Packages
         inputs:
           pathToPublish: '$(Build.ArtifactStagingDirectory)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -47,15 +47,16 @@ jobs:
           testRunTitle: 'Outerloop Tests'
           buildConfiguration: '$(Config)'
           searchFolder: '$(Build.SourcesDirectory)/artifacts/test-results'
-      - ${{ if eq(variables['Config'], 'Release') }}:
-        - task: CopyFiles@2
-          displayName: 'Copy NuGet packages to Artifact staging directory'
-          inputs:
-            contents: 'Sharp*/**/Sharp*.nupkg'
-            targetFolder: '$(Build.ArtifactStagingDirectory)'
-            flattenFolders: true
-        - task: PublishBuildArtifacts@1
-          displayName: Publish NuGet Packages
-          inputs:
-            pathToPublish: '$(Build.ArtifactStagingDirectory)'
-            artifactName: NuGet Packages
+      - task: CopyFiles@2
+        condition: eq(variables['Config'], 'Release')
+        displayName: 'Copy NuGet packages to Artifact staging directory'
+        inputs:
+          contents: 'Sharp*/**/Sharp*.nupkg'
+          targetFolder: '$(Build.ArtifactStagingDirectory)'
+          flattenFolders: true
+      - task: PublishBuildArtifacts@1
+        condition: eq(variables['Config'], 'Release')
+        displayName: Publish NuGet Packages
+        inputs:
+          pathToPublish: '$(Build.ArtifactStagingDirectory)'
+          artifactName: NuGet Packages

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,6 +20,8 @@ jobs:
           Config: 'Release'
     variables:
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: "true"
+      ReleaseVersion: ''
+      CI: true
     steps:
       - pwsh: |
           if ($env:SourceBranch -match 'refs/tags/v(?<Version>.+)')
@@ -43,13 +45,11 @@ jobs:
         env:
           ReleaseTag: '$(ReleaseVersion)'
           BuildNumber: '$(Build.BuildNumber)'
-          CI: true
       - pwsh: ./test.ps1 -Configuration $(Config)
         displayName: 'Run Tests'
         env:
           ReleaseTag: '$(ReleaseVersion)'
           BuildNumber: '$(Build.BuildNumber)'
-          CI: true
       - task: PublishTestResults@2
         displayName: 'Publish unit test results'
         inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,7 +1,13 @@
 trigger:
-- master
-pr:
-- master
+  branches:
+    include:
+      - master
+  pr:
+    include:
+      - master
+  tags:
+    include:
+      - v*.*
 
 jobs:
   - job: SharpGenTools_Windows
@@ -16,6 +22,14 @@ jobs:
     variables:
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: "true"
     steps:
+      - pwsh: |
+          if ($env:SourceBranch -Matches 'refs/tags/v(?<Version>.+)')
+          {
+            Write-Host "##vso[task.setvariable variable=ReleaseVersion;]$Matches.Version"
+          }
+        displayName: 'Get Release Name (if this is a tag-triggered build)'
+        env:
+          SourceBranch : '$(Build.SourceBranch)'
       - task: UseDotNet@2
         displayName: 'Install .NET Core Sdk'
         inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,18 +33,7 @@ jobs:
         displayName: 'Publish unit test results'
         inputs:
           testResultsFormat: 'VSTest'
-          testResultsFiles: 'SharpGen*.trx'
-          mergeTestResults: true
-          testRunTitle: 'Unit Tests'
-          buildConfiguration: '$(Config)'
-          searchFolder: '$(Build.SourcesDirectory)/artifacts/test-results'
-      - task: PublishTestResults@2
-        displayName: 'Publish outerloop test results'
-        inputs:
-          testResultsFormat: 'VSTest'
-          testResultsFiles: '*.trx;!SharpGen*.trx'
-          mergeTestResults: true
-          testRunTitle: 'Outerloop Tests'
+          testResultsFiles: '*.trx'
           buildConfiguration: '$(Config)'
           searchFolder: '$(Build.SourcesDirectory)/artifacts/test-results'
       - task: CopyFiles@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,7 +18,7 @@ jobs:
         displayName: 'Install .NET Core Sdk'
         inputs:
           packageType: sdk
-          version: 2.1.x
+          version: 2.2.x
       - script: |
           dotnet tool install --global coverlet.console
           dotnet tool install --global CodeCov.Tool

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,8 +40,16 @@ jobs:
         displayName: 'Install Code Coverage Tools'
       - pwsh: ./build.ps1 -Configuration $(Config)
         displayName: 'Build SharpGenTools'
+        env:
+          ReleaseTag: '$(ReleaseVersion)'
+          BuildNumber: '$(Build.BuildNumber)'
+          CI: true
       - pwsh: ./test.ps1 -Configuration $(Config)
         displayName: 'Run Tests'
+        env:
+          ReleaseTag: '$(ReleaseVersion)'
+          BuildNumber: '$(Build.BuildNumber)'
+          CI: true
       - task: PublishTestResults@2
         displayName: 'Publish unit test results'
         inputs:

--- a/build/Run-CodeCoverage.ps1
+++ b/build/Run-CodeCoverage.ps1
@@ -3,17 +3,15 @@ Param(
     [string] $Assembly,
     [string] $Executable,
     [string[]] $Arguments,
-    [string[]] $Filters,
     [string] $Output)
 
 
 $ScriptFolder = Split-Path -parent $PSCommandPath
 
 $targetArgs = $($Arguments -join ' ')
-$filter = $($Filters -join '%2c')
 
-coverlet "$AssemblyFolder/SharpGenTools.Sdk.dll" -t $Executable -a $targetArgs --include $filter `
-     -f opencover -o $ScriptFolder/../artifacts/coverage/$Output --include-test-assembly --include-directory $AssemblyFolder `
+coverlet "$AssemblyFolder/SharpGenTools.Sdk.dll" -t $Executable -a $targetArgs -f opencover `
+     -o $ScriptFolder/../artifacts/coverage/$Output --include-test-assembly --include-directory $AssemblyFolder `
      | Write-Host
 
 return $LastExitCode -eq 0

--- a/build/Run-UnitTest.ps1
+++ b/build/Run-UnitTest.ps1
@@ -10,5 +10,6 @@ Param(
 dotnet test "$RepoRoot/$TestSubdirectory/$Project/$Project.csproj" --no-build --no-restore -c $Configuration /p:CollectCoverage=$CollectCoverage `
     /p:Include='[SharpGen]*%2c[SharpGen.Runtime]*' /p:IncludeDirectory="$CoverageIncludeDirectory" `
     /p:CoverletOutputFormat=opencover /p:CoverletOutput="$RepoRoot/artifacts/coverage/$Project.xml" `
+    --logger "trx;LogFileName=$RepoRoot/artifacts/test-results/$Project.trx" `
     | Write-Host
 return $LastExitCode -eq 0

--- a/build/build-outerloop.ps1
+++ b/build/build-outerloop.ps1
@@ -14,11 +14,10 @@ $env:Path += ";C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.
 
 $dotnetExe = $(Get-Command dotnet).Path
 
-$dotnetParameters =  "build", "./SdkTests/SdkTests.sln", "/nodeReuse:false", "--no-restore"
-$coverageFilter = "[SharpGen]*", "[SharpGenTools.Sdk]*"
+$dotnetParameters =  "build", "./SdkTests/SdkTests.sln", "-nr:false", "-m:1" # Force no parallelization to work around https://github.com/tonerdo/coverlet/issues/491
 
 if ($RunCodeCoverage) {
-    return (./build/Run-CodeCoverage $SdkAssemblyFolder "SharpGenTools.Sdk.dll" $dotnetExe $dotnetParameters $coverageFilter "outerloop-build.xml")
+    return (./build/Run-CodeCoverage $SdkAssemblyFolder "SharpGenTools.Sdk.dll" $dotnetExe $dotnetParameters "outerloop-build.xml")
 }
 else {
     dotnet build ./SdkTests/SdkTests.sln | Write-Host

--- a/build/run-outerloop-tests.ps1
+++ b/build/run-outerloop-tests.ps1
@@ -9,8 +9,6 @@ $SharpGenRuntimePath = "$RepoRoot/SdkTests/RestoredPackages/sharpgen.runtime/$Sh
 
 $managedTests = "Interface", "Struct", "Functions"
 
-Write-Host "Coverage Include directory : $SharpGenRuntimePath"
-
 foreach($test in $managedTests) {
     ./build/Run-UnitTest -Project $test -Configuration "Debug" -CollectCoverage $RunCodeCoverage `
          -RepoRoot $RepoRoot -TestSubdirectory "SdkTests" -CoverageIncludeDirectory $SharpGenRuntimePath

--- a/test.ps1
+++ b/test.ps1
@@ -46,7 +46,3 @@ if(!($SkipOuterloopTests)) {
         exit 1
     }
 }
-
-if ($RunCodeCoverage -and $env:CI) {
-    ./build/upload-coverage.ps1
-}


### PR DESCRIPTION
Enable building on Azure Pipelines.

TODO:

- [x] Package version suffix on CI
- [x] Support for tag-based triggers
- [x] Package deployment (MyGet)
- [x] Set starting build number in AzDO
- [x] Publish test results
- [x] Enable Code Coverage report upload