### PR TITLE
Ability to override marshalling methods in generator

### DIFF
--- a/SharpGen.Runtime.UnitTests/CppObjectTests.cs
+++ b/SharpGen.Runtime.UnitTests/CppObjectTests.cs
@@ -12,7 +12,7 @@ namespace SharpGen.Runtime.UnitTests
         {
             using (var callback = new CallbackImpl())
             {
-                Assert.NotEqual(IntPtr.Zero, CppObject.ToCallbackPtr<ICallback>(callback));
+                Assert.NotEqual(IntPtr.Zero, MarshallingHelpers.ToCallbackPtr<ICallback>(callback));
             }
         }
 
@@ -21,8 +21,8 @@ namespace SharpGen.Runtime.UnitTests
         {
             using (var callback = new Callback2Impl())
             {
-                Assert.NotEqual(IntPtr.Zero, CppObject.ToCallbackPtr<ICallback>(callback));
-                Assert.NotEqual(IntPtr.Zero, CppObject.ToCallbackPtr<ICallback2>(callback));
+                Assert.NotEqual(IntPtr.Zero, MarshallingHelpers.ToCallbackPtr<ICallback>(callback));
+                Assert.NotEqual(IntPtr.Zero, MarshallingHelpers.ToCallbackPtr<ICallback2>(callback));
             }
         }
     }

--- a/SharpGen.Runtime.UnitTests/VtblTests.cs
+++ b/SharpGen.Runtime.UnitTests/VtblTests.cs
@@ -11,7 +11,7 @@ namespace SharpGen.Runtime.UnitTests
         {
             using (var callback = new CallbackImpl())
             {
-                var callbackPtr = CppObject.ToCallbackPtr<ICallback>(callback);
+                var callbackPtr = MarshallingHelpers.ToCallbackPtr<ICallback>(callback);
                 var methodPtr = Marshal.ReadIntPtr(Marshal.ReadIntPtr(callbackPtr));
                 var delegateObject = Marshal.GetDelegateForFunctionPointer<CallbackShadow.CallbackVbtl.IncrementDelegate>(methodPtr);
                 Assert.Equal(3, delegateObject(callbackPtr, 2));

--- a/SharpGen.Runtime/CppObject.cs
+++ b/SharpGen.Runtime/CppObject.cs
@@ -146,56 +146,6 @@ namespace SharpGen.Runtime
         }
 
         /// <summary>
-        /// Instantiate a CppObject from a native pointer.
-        /// </summary>
-        /// <typeparam name="T">The CppObject class that will be returned</typeparam>
-        /// <param name="cppObjectPtr">The native pointer to a com object.</param>
-        /// <returns>An instance of T binded to the native pointer</returns>
-        public static T FromPointer<T>(IntPtr comObjectPtr) where T : CppObject
-        {
-            return (comObjectPtr == IntPtr.Zero) ? null : (T) Activator.CreateInstance(typeof (T), comObjectPtr);
-        }
-
-        /// <summary>
-        /// Return the unmanaged C++ pointer from a <see cref="ICallbackable"/> instance.
-        /// </summary>
-        /// <typeparam name="TCallback">The type of the callback.</typeparam>
-        /// <param name="callback">The callback.</param>
-        /// <returns>A pointer to the unmanaged C++ object of the callback</returns>
-        public static IntPtr ToCallbackPtr<TCallback>(ICallbackable callback)
-            where TCallback : ICallbackable
-        {
-            // If callback is null, then return a null pointer
-            if (callback == null)
-                return IntPtr.Zero;
-
-            // If callback is CppObject
-            if (callback is CppObject cpp)
-                return cpp.NativePointer;
-
-            // Setup the shadow container in order to support multiple inheritance
-            var shadowContainer = callback.Shadow;
-            if (shadowContainer == null)
-            {
-                callback.Shadow = new ShadowContainer(callback);
-                shadowContainer = callback.Shadow;
-            }
-
-            return shadowContainer.Find(typeof(TCallback));
-        }
-
-        /// <summary>
-        /// Return the unmanaged C++ pointer from a <see cref="CppObject"/> instance.
-        /// </summary>
-        /// <typeparam name="TCallback">The type of the callback.</typeparam>
-        /// <param name="obj">The object.</param>
-        /// <returns>A pointer to the unmanaged C++ object of the callback</returns>
-        /// <remarks>This method is meant as a fast-path for codegen to use to reduce the number of casts.</remarks>
-        public static IntPtr ToCallbackPtr<TCallback>(CppObject obj)
-            where TCallback : ICallbackable
-            => obj?.NativePointer ?? IntPtr.Zero;
-
-        /// <summary>
         /// Implements <see cref="ICallbackable"/> but it cannot not be set. 
         /// This is only used to support for interop with unmanaged callback.
         /// </summary>

--- a/SharpGen.Runtime/MarshallingHelpers.cs
+++ b/SharpGen.Runtime/MarshallingHelpers.cs
@@ -1,0 +1,95 @@
+// Copyright (c) 2010-2014 SharpDX - Alexandre Mutel
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using System.Runtime.CompilerServices;
+
+namespace SharpGen.Runtime
+{
+    /// <summary>
+    /// Helper class providing methods for marshalling interfaces/classes between managed and unmanaged code
+    /// </summary>
+    public static class MarshallingHelpers
+    {
+        /// <summary>
+        /// Instantiate a CppObject from a native pointer.
+        /// </summary>
+        /// <typeparam name="T">The CppObject class that will be returned</typeparam>
+        /// <param name="cppObjectPtr">The native pointer to a com object.</param>
+        /// <returns>An instance of T binded to the native pointer</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static T FromPointer<T>(IntPtr comObjectPtr) where T : CppObject
+        {
+            return (comObjectPtr == IntPtr.Zero) ? null : (T) Activator.CreateInstance(typeof (T), comObjectPtr);
+        }
+
+        /// <summary>
+        /// Return the unmanaged C++ pointer from a <see cref="SharpGen.Runtime.ICallbackable"/> instance.
+        /// </summary>
+        /// <typeparam name="TCallback">The type of the callback.</typeparam>
+        /// <param name="callback">The callback.</param>
+        /// <returns>A pointer to the unmanaged C++ object of the callback</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static IntPtr ToCallbackPtr<TCallback>(ICallbackable callback)
+            where TCallback : ICallbackable
+        {
+            // If callback is null, then return a null pointer
+            if (callback == null)
+                return IntPtr.Zero;
+
+            // If callback is CppObject
+            if (callback is CppObject cpp)
+                return cpp.NativePointer;
+
+            // Setup the shadow container in order to support multiple inheritance
+            var shadowContainer = callback.Shadow;
+            if (shadowContainer == null)
+            {
+                callback.Shadow = new ShadowContainer(callback);
+                shadowContainer = callback.Shadow;
+            }
+
+            return shadowContainer.Find(typeof(TCallback));
+        }
+
+        /// <summary>
+        /// Return the unmanaged C++ pointer from a <see cref="SharpGen.Runtime.CppObject"/> instance.
+        /// </summary>
+        /// <typeparam name="TCallback">The type of the callback.</typeparam>
+        /// <param name="obj">The object.</param>
+        /// <returns>A pointer to the unmanaged C++ object of the callback</returns>
+        /// <remarks>This method is meant as a fast-path for codegen to use to reduce the number of casts.</remarks>
+        public static IntPtr ToCallbackPtr<TCallback>(CppObject obj)
+            where TCallback : ICallbackable 
+            => obj?.NativePointer ?? IntPtr.Zero;
+
+        /// <summary>
+        /// Makes additional transformation for the object which was unmarshalled from unmanaged code 
+        /// </summary>
+        /// <param name="obj"></param>
+        /// <param name="isOutParam">Indicates that the object was obtained via 'Obj**' parameter</param>
+        /// <returns>Transformed object</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static T TransformObjectFromUnmanaged<T>(T obj, bool isOutParam) where T : CppObject
+        {
+            return obj;
+        }
+    }
+}

--- a/SharpGen/GlobalNamespaceProvider.cs
+++ b/SharpGen/GlobalNamespaceProvider.cs
@@ -79,7 +79,11 @@ namespace SharpGen
         /// <summary>
         /// Native `unsigned long` type
         /// </summary>
-        NativeULong
+        NativeULong,
+        /// <summary>
+        /// Helper class for marshalling interface/class types
+        /// </summary>
+        MarshallingHelpers
     }
 
     /// <summary>


### PR DESCRIPTION
Move marshalling methods from CppObject to special class MarshallingHelpers and add an ability to override this class in generator. This allows to replace these methods for COM objects to perform AddRef/Release properly