### PR TITLE
Generate callback method signatures even if autogen-shadow is set to false

### DIFF
--- a/SharpGen/Generator/MethodCodeGenerator.cs
+++ b/SharpGen/Generator/MethodCodeGenerator.cs
@@ -36,12 +36,6 @@ namespace SharpGen.Generator
                     .WithModifiers(TokenList(Token(SyntaxKind.PrivateKeyword)));
             }
 
-            // If not hidden, generate body
-            if (csElement.Hidden)
-            {
-                yield break;
-            }
-
             foreach (var member in Generators.Callable.GenerateCode(csElement))
             {
                 yield return member;


### PR DESCRIPTION
The documentation says that callback signatures generation is not supported if autogen-shadows is off. But I've tried to enable it and it works good.
If you need to keep interfaces empty - you just remove it's method in mapping by mask