### PR TITLE
Fix UnitTests forcing SDK NuGet package to be broken

### DIFF
--- a/SharpGen.Platform/Documentation/DocConverterUtilities.cs
+++ b/SharpGen.Platform/Documentation/DocConverterUtilities.cs
@@ -1,10 +1,8 @@
 using System.Collections.Generic;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using SharpGen.Doc;
-using SharpGenTools.Sdk.Internal;
 
-namespace SharpGenTools.Sdk.Documentation
+namespace SharpGen.Platform.Documentation
 {
     internal static class DocConverterUtilities
     {

--- a/SharpGen.Platform/Documentation/DocItem.cs
+++ b/SharpGen.Platform/Documentation/DocItem.cs
@@ -4,11 +4,10 @@ using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.Linq;
 using SharpGen.Doc;
-using SharpGenTools.Sdk.Internal;
 
-namespace SharpGenTools.Sdk.Documentation
+namespace SharpGen.Platform.Documentation
 {
-    public sealed class DocItem : IDocItem
+    internal sealed class DocItem : IDocItem
     {
         private readonly ObservableCollection<IDocSubItem> items = new();
 

--- a/SharpGen.Platform/Documentation/DocItemCache.cs
+++ b/SharpGen.Platform/Documentation/DocItemCache.cs
@@ -4,11 +4,10 @@ using System.IO;
 using System.Linq;
 using System.Text.Json;
 using SharpGen.Doc;
-using SharpGenTools.Sdk.Internal;
 
-namespace SharpGenTools.Sdk.Documentation
+namespace SharpGen.Platform.Documentation
 {
-    internal class DocItemCache
+    public sealed class DocItemCache
     {
         private readonly object syncObject = new();
 
@@ -41,8 +40,6 @@ namespace SharpGenTools.Sdk.Documentation
 
         public static DocItemCache Read(string file)
         {
-            Utilities.RequireAbsolutePath(file, nameof(file));
-
             return JsonSerializer.Deserialize<DocItemCache>(File.ReadAllBytes(file), JsonSerializerOptions);
         }
 
@@ -52,8 +49,6 @@ namespace SharpGenTools.Sdk.Documentation
         /// <param name="file">The file.</param>
         public void Write(string file)
         {
-            Utilities.RequireAbsolutePath(file, nameof(file));
-
             using var output = File.Create(file);
             using var writer = new Utf8JsonWriter(output);
 
@@ -69,8 +64,6 @@ namespace SharpGenTools.Sdk.Documentation
         /// <param name="file">The file.</param>
         public void WriteIfDirty(string file)
         {
-            Utilities.RequireAbsolutePath(file, nameof(file));
-
             if (File.Exists(file))
             {
                 bool touch;

--- a/SharpGen.Platform/Documentation/DocItemConverter.cs
+++ b/SharpGen.Platform/Documentation/DocItemConverter.cs
@@ -5,9 +5,9 @@ using System.Collections.Generic;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using SharpGen.Doc;
-using static SharpGenTools.Sdk.Documentation.DocConverterUtilities;
+using static SharpGen.Platform.Documentation.DocConverterUtilities;
 
-namespace SharpGenTools.Sdk.Documentation
+namespace SharpGen.Platform.Documentation
 {
     internal sealed class DocItemConverter : JsonConverter<IDocItem>
     {

--- a/SharpGen.Platform/Documentation/DocSubItem.cs
+++ b/SharpGen.Platform/Documentation/DocSubItem.cs
@@ -2,12 +2,11 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using SharpGen.Doc;
-using SharpGenTools.Sdk.Internal;
 
-namespace SharpGenTools.Sdk.Documentation
+namespace SharpGen.Platform.Documentation
 {
     /// <inheritdoc />
-    public sealed class DocSubItem : IDocSubItem
+    internal sealed class DocSubItem : IDocSubItem
     {
         private readonly ObservableSet<string> attributes =
             new(StringComparer.InvariantCultureIgnoreCase);

--- a/SharpGen.Platform/Documentation/DocSubItemConverter.cs
+++ b/SharpGen.Platform/Documentation/DocSubItemConverter.cs
@@ -5,9 +5,9 @@ using System.Collections.Generic;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using SharpGen.Doc;
-using static SharpGenTools.Sdk.Documentation.DocConverterUtilities;
+using static SharpGen.Platform.Documentation.DocConverterUtilities;
 
-namespace SharpGenTools.Sdk.Documentation
+namespace SharpGen.Platform.Documentation
 {
     internal sealed class DocSubItemConverter : JsonConverter<IDocSubItem>
     {

--- a/SharpGen.Platform/ObservableSet.cs
+++ b/SharpGen.Platform/ObservableSet.cs
@@ -3,7 +3,7 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 
-namespace SharpGenTools.Sdk.Internal
+namespace SharpGen.Platform
 {
     public sealed class ObservableSet<T> : ObservableCollection<T>
     {

--- a/SharpGen.Platform/SharpGen.Platform.csproj
+++ b/SharpGen.Platform/SharpGen.Platform.csproj
@@ -10,16 +10,44 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.Win32.Registry" Condition="'$(TargetFramework)' != 'net472'" />
         <PackageReference Include="System.Diagnostics.Process" Condition="'$(TargetFramework)' != 'net472'" />
+        <PackageReference Include="System.Text.Json" />
     </ItemGroup>
 
     <ItemGroup>
         <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
             <_Parameter1>SharpGen.UnitTests</_Parameter1>
         </AssemblyAttribute>
+        <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+            <_Parameter1>SharpGenTools.Sdk</_Parameter1>
+        </AssemblyAttribute>
     </ItemGroup>
 
     <ItemGroup>
         <ProjectReference Include="..\SharpGen\SharpGen.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <Compile Update="Documentation\DocConverterUtilities.cs">
+        <SubType>Code</SubType>
+      </Compile>
+      <Compile Update="Documentation\DocItemCache.cs">
+        <SubType>Code</SubType>
+      </Compile>
+      <Compile Update="Documentation\DocItem.cs">
+        <SubType>Code</SubType>
+      </Compile>
+      <Compile Update="Documentation\DocItemConverter.cs">
+        <SubType>Code</SubType>
+      </Compile>
+      <Compile Update="Documentation\DocSubItemConverter.cs">
+        <SubType>Code</SubType>
+      </Compile>
+      <Compile Update="Documentation\DocSubItem.cs">
+        <SubType>Code</SubType>
+      </Compile>
+      <Compile Update="ObservableSet.cs">
+        <SubType>Code</SubType>
+      </Compile>
     </ItemGroup>
 
 </Project>

--- a/SharpGen.UnitTests/Sdk/DocItemConverterTests.cs
+++ b/SharpGen.UnitTests/Sdk/DocItemConverterTests.cs
@@ -1,6 +1,6 @@
 using System.Linq;
 using System.Text.Json;
-using SharpGenTools.Sdk.Documentation;
+using SharpGen.Platform.Documentation;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/SharpGen.UnitTests/SharpGen.UnitTests.csproj
+++ b/SharpGen.UnitTests/SharpGen.UnitTests.csproj
@@ -10,7 +10,6 @@
   <ItemGroup>
     <ProjectReference Include="..\SharpGen.Platform\SharpGen.Platform.csproj" />
     <ProjectReference Include="..\SharpGen.Runtime\SharpGen.Runtime.csproj" />
-    <ProjectReference Include="..\SharpGenTools.Sdk\SharpGenTools.Sdk.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SharpGenTools.Sdk/Documentation/DocProviderExecutor.cs
+++ b/SharpGenTools.Sdk/Documentation/DocProviderExecutor.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using Polly.Contrib.WaitAndRetry;
 using SharpGen.CppModel;
 using SharpGen.Doc;
+using SharpGen.Platform.Documentation;
 
 namespace SharpGenTools.Sdk.Documentation
 {

--- a/SharpGenTools.Sdk/Documentation/DocumentationContext.cs
+++ b/SharpGenTools.Sdk/Documentation/DocumentationContext.cs
@@ -1,6 +1,8 @@
 using System;
 using SharpGen.Doc;
 using SharpGen.Logging;
+using SharpGen.Platform;
+using SharpGen.Platform.Documentation;
 using SharpGenTools.Sdk.Internal;
 
 #nullable enable

--- a/SharpGenTools.Sdk/Extensibility/ExtensibilityDriver.cs
+++ b/SharpGenTools.Sdk/Extensibility/ExtensibilityDriver.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 using SharpGen.CppModel;
 using SharpGen.Doc;
 using SharpGen.Logging;
+using SharpGen.Platform.Documentation;
 using SharpGenTools.Sdk.Documentation;
 using SharpGenTools.Sdk.Internal;
 using SharpGenTools.Sdk.Internal.Roslyn;

--- a/SharpGenTools.Sdk/SharpGenTools.Sdk.csproj
+++ b/SharpGenTools.Sdk/SharpGenTools.Sdk.csproj
@@ -33,7 +33,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Build.Utilities.Core" />
     <PackageReference Include="Microsoft.Bcl.HashCode" />
-    <PackageReference Include="System.Text.Json" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" />
     <PackageReference Include="Polly.Contrib.WaitAndRetry" />
     <PackageReference Include="Nullable" />

--- a/SharpGenTools.Sdk/Tasks/SharpGenTask.cs
+++ b/SharpGenTools.Sdk/Tasks/SharpGenTask.cs
@@ -13,6 +13,7 @@ using SharpGen.Logging;
 using SharpGen.Model;
 using SharpGen.Parser;
 using SharpGen.Platform;
+using SharpGen.Platform.Documentation;
 using SharpGen.Transform;
 using SharpGenTools.Sdk.Documentation;
 using SharpGenTools.Sdk.Extensibility;


### PR DESCRIPTION
`UnitTests` depended on SDK package, but MSBuildSdkExtras handles RID-specific output directories correctly for `Pack`, not for ProjectReference inner-`Build`. This caused erroneous output directories and extra files in the wrong places. .NET Core MSBuild `tools` folder was unnecessarily large.