### PR TITLE
Build fails when project has spaces in path

### DIFF
--- a/SharpGen.Platform/CastXmlRunner.cs
+++ b/SharpGen.Platform/CastXmlRunner.cs
@@ -105,7 +105,7 @@ namespace SharpGen.Platform
                 // Delete any previously generated xml file
                 File.Delete(xmlFile);
 
-                RunCastXml(headerFile, LogCastXmlOutput, $"-o {xmlFile}");
+                RunCastXml(headerFile, LogCastXmlOutput, $"-o \"{xmlFile}\"");
 
                 if (!File.Exists(xmlFile) || Logger.HasErrors)
                 {


### PR DESCRIPTION
Build fails when project or include directory has spaces in the path.