### PR TITLE
Workaround for UWP .Net native build

### DIFF
--- a/SharpGen.Runtime/Result.cs
+++ b/SharpGen.Runtime/Result.cs
@@ -31,23 +31,24 @@ namespace SharpGen.Runtime
     [StructLayout(LayoutKind.Sequential)]
     public readonly partial struct Result : IEquatable<Result>
     {
+        private readonly int _code;
+
         /// <summary>
         /// Gets the HRESULT error code.
         /// </summary>
         /// <value>The HRESULT error code.</value>
-        public int Code { get; }
+        public int Code { get => _code; }
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Result"/> struct.
+        /// </summary>
+        /// <param name="code">The HRESULT error code.</param>
+        public Result(int code) => _code = code;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Result"/> struct.
         /// </summary>
         /// <param name="code">The HRESULT error code.</param>
-        public Result(int code) => Code = code;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Result"/> struct.
-        /// </summary>
-        /// <param name="code">The HRESULT error code.</param>
-        public Result(uint code) => Code = unchecked((int)code);
+        public Result(uint code) => _code = unchecked((int)code);
 
         /// <summary>
         /// Gets a value indicating whether this <see cref="Result"/> is success.


### PR DESCRIPTION
Build a project that references [Vortice](https://github.com/amerkoleci/Vortice.Windows) using UWP .Net Native throws the following exception:
 
````
Microsoft.NetNative.targets(801,5): error : MCG0037: MCG0037:InvalidCSharpIdentifierName Struct 'SharpGen.Runtime.Result' in assembly 'Assembly(Name=SharpGen.Runtime, Version=2.0.0.0, Culture=neutral, PublicKeyToken=a7c0d43f556c6402)' has a field with name '<Code>k__BackingField' that is invalid. This could be because the name is obfuscated or the field is auto-implemented by the compiler. Please make sure the field name follows C# identifier conventions.
````

[This issue has been reported 3 years ago](https://github.com/microsoft/dotnet/issues/807), but the only solution is to avoid the use of auto-properties.... 

You can reproduce the issue creating a new UWP project, adding the SharpGen.Runtime and adding the following line in the MainPage.xaml.cs:
````
Marshal.SizeOf<Result>();
````
