### PR TITLE
Fix document generation.

### DIFF
--- a/SharpGen/Model/CsBase.cs
+++ b/SharpGen/Model/CsBase.cs
@@ -206,6 +206,15 @@ public abstract class CsBase
     }
 
     /// <summary>
+    /// Gets the full name of the C++ element.
+    /// </summary>
+    /// <value>The name of the C++ element.</value>
+    public string CppElementFullName
+    {
+        get => CppElement?.FullName ?? CppElementName;
+    }
+
+    /// <summary>
     /// Gets or sets the doc id.
     /// </summary>
     public string DocId { get; set; }

--- a/SharpGen/Transform/ExternalDocCommentsReader.cs
+++ b/SharpGen/Transform/ExternalDocCommentsReader.cs
@@ -42,6 +42,6 @@ public class ExternalDocCommentsReader
 
     private static string GetExternalDocCommentId(CsBase element)
     {
-        return element.CppElementName ?? element.QualifiedName;
+        return element.CppElementFullName ?? element.QualifiedName;
     }
 }

--- a/SharpGen/Transform/TransformServiceExtensions.cs
+++ b/SharpGen/Transform/TransformServiceExtensions.cs
@@ -50,7 +50,7 @@ public static class TransformServiceExtensions
         }
         else
         {
-            docItems.Add($"<include file='{externalCommentsPath}' path=\"{ExternalDocCommentsReader.GetCodeCommentsXPath(element)}/*\" />");
+            docItems.Add($"<include file=\"{externalCommentsPath}\" path=\"{ExternalDocCommentsReader.GetCodeCommentsXPath(element)}/*\" />");
         }
 
         if (element.CppElementName != null)

--- a/docs/documentation.rst
+++ b/docs/documentation.rst
@@ -12,12 +12,31 @@ You can supply external documentation though XML files structured as below:
 .. code-block:: xml
 
     <comments>
-        <comment id="C++ or C# Element Name">
+        <comment id="Full C++ element name">
             <summary>Summary here</summary>
+        </comment>
+        <comment id="DML_BUFFER_BINDING">
+            <summary>An example summary for a C++ struct named DML_BUFFER_BINDING.</summary>
+        </comment>
+        <comment id="DML_BUFFER_BINDING::Buffer">
+            <summary>An example summary for a C++ field named Buffer within a struct named DML_BUFFER_BINDING.</summary>
         </comment>
     </comments>
 
-SharpGenTools will automatically include an ``<include>`` documentation tag that points to a matching element in an external documentation file. You can specify an external comments file to SharpGen by adding it as a ``SharpGenExternalDocs`` item in your project file.
+SharpGenTools will automatically add an ``<include>`` documentation tag to matching elements in the generated code. This tag will point to the matching element in an external documentation file. You can specify an external comments file to SharpGen by adding it as a ``SharpGenExternalDocs`` item in your project file.
+
+An example project file that supports documentation:
+
+.. code-block:: xml
+
+    <Project Sdk="Microsoft.NET.Sdk">
+        ...
+        <ItemGroup>
+            <SharpGenMapping Include="Mappings.xml" />
+            <SharpGenExternalDocs Include="Documentation.xml" />
+            ...
+        </ItemGroup>
+    </Project>
 
 Doc Providers
 ==================


### PR DESCRIPTION
My previous pull request #170 had a typo in referenced documentation generation. In addition, we change the documentation matching to use the CppFullName instead of the name. We can now specify documentation for a member field `DML_BUFFER_BINDING::Buffer` instead of all fields named `Buffer`.